### PR TITLE
Refactor calls management logic

### DIFF
--- a/pkg/cmd/cfg.go
+++ b/pkg/cmd/cfg.go
@@ -5,15 +5,15 @@ import (
 	"strings"
 
 	"github.com/ksysoev/deriv-api-bff/pkg/api"
-	"github.com/ksysoev/deriv-api-bff/pkg/core"
 	"github.com/ksysoev/deriv-api-bff/pkg/prov/deriv"
+	"github.com/ksysoev/deriv-api-bff/pkg/repo"
 	"github.com/spf13/viper"
 )
 
 type config struct {
-	Server api.Config   `mapstructure:"server"`
-	Deriv  deriv.Config `mapstructure:"deriv"`
-	API    core.Config  `mapstructure:"api"`
+	Server api.Config       `mapstructure:"server"`
+	Deriv  deriv.Config     `mapstructure:"deriv"`
+	API    repo.CallsConfig `mapstructure:"api"`
 }
 
 // initConfig initializes the configuration by reading from the specified config file.

--- a/pkg/cmd/server.go
+++ b/pkg/cmd/server.go
@@ -18,10 +18,12 @@ func runServer(ctx context.Context, cfg *config) error {
 
 	connRegistry := repo.NewConnectionRegistry()
 
-	requestHandler, err := core.NewService(&cfg.API, derivAPI, connRegistry)
+	calls, err := repo.NewCallsRepository(&cfg.API)
 	if err != nil {
-		return fmt.Errorf("failed to create request handler: %w", err)
+		return fmt.Errorf("failed to create calls repo: %w", err)
 	}
+
+	requestHandler := core.NewService(calls, derivAPI, connRegistry)
 
 	server := api.NewSevice(&cfg.Server, requestHandler)
 

--- a/pkg/core/handler.go
+++ b/pkg/core/handler.go
@@ -8,7 +8,7 @@ import (
 )
 
 type CallsRepo interface {
-	GetCall(method string) (*CallRunConfig, bool)
+	GetCall(method string) *CallRunConfig
 }
 
 var ErrIterDone = errors.New("iteration done")
@@ -50,9 +50,8 @@ func NewCallHandler(repo CallsRepo) *CallHandler {
 func (h *CallHandler) Process(req *Request) (*RequesIter, error) {
 	method := req.RoutingKey()
 
-	call, ok := h.repo.GetCall(method)
-
-	if !ok {
+	call := h.repo.GetCall(method)
+	if call == nil {
 		return nil, fmt.Errorf("unsupported method: %s", method)
 	}
 

--- a/pkg/core/svc.go
+++ b/pkg/core/svc.go
@@ -24,18 +24,14 @@ type Service struct {
 // It takes cfg of type *Config, wsBackend of type DerivAPI, and connRegistry of type ConnRegistry.
 // It returns a pointer to Service and an error.
 // It returns an error if the call handler creation fails.
-func NewService(cfg *Config, wsBackend DerivAPI, connRegistry ConnRegistry) (*Service, error) {
-	callHandler, err := NewCallHandler(cfg)
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to create call handler: %w", err)
-	}
+func NewService(calls CallsRepo, wsBackend DerivAPI, connRegistry ConnRegistry) *Service {
+	callHandler := NewCallHandler(calls)
 
 	return &Service{
 		be:       wsBackend,
 		ch:       callHandler,
 		registry: connRegistry,
-	}, nil
+	}
 }
 
 // PassThrough forwards a request to the backend service using the provided client connection.

--- a/pkg/repo/callconfig.go
+++ b/pkg/repo/callconfig.go
@@ -1,0 +1,63 @@
+package repo
+
+import (
+	"html/template"
+
+	"github.com/ksysoev/deriv-api-bff/pkg/core"
+)
+
+type CallsConfig struct {
+	Calls []CallConfig `mapstructure:"calls"`
+}
+
+type CallConfig struct {
+	Method  string            `mapstructure:"method"`
+	Params  map[string]string `mapstructure:"params"`
+	Backend []BackendConfig   `mapstructure:"backend"`
+}
+
+type BackendConfig struct {
+	FieldsMap       map[string]string `mapstructure:"fields_map"`
+	ResponseBody    string            `mapstructure:"response_body"`
+	RequestTemplate string            `mapstructure:"request_template"`
+	Allow           []string          `mapstructure:"allow"`
+}
+
+type CallsRepository struct {
+	calls map[string]*core.CallRunConfig
+}
+
+func NewCallsRepository(cfg *CallsConfig) (*CallsRepository, error) {
+	r := &CallsRepository{
+		calls: make(map[string]*core.CallRunConfig),
+	}
+
+	for _, call := range cfg.Calls {
+		c := &core.CallRunConfig{
+			Requests: make(map[string]*core.RequestRunConfig),
+		}
+
+		for _, req := range call.Backend {
+			tmplt, err := template.New("request").Parse(req.RequestTemplate)
+			if err != nil {
+				return nil, err
+			}
+
+			c.Requests[req.ResponseBody] = &core.RequestRunConfig{
+				Tmplt:        tmplt,
+				Allow:        req.Allow,
+				FieldMap:     req.FieldsMap,
+				ResponseBody: req.ResponseBody,
+			}
+		}
+
+		r.calls[call.Method] = c
+	}
+
+	return r, nil
+}
+
+func (r *CallsRepository) GetCall(method string) (*core.CallRunConfig, bool) {
+	c, ok := r.calls[method]
+	return c, ok
+}

--- a/pkg/repo/callrepo.go
+++ b/pkg/repo/callrepo.go
@@ -57,7 +57,6 @@ func NewCallsRepository(cfg *CallsConfig) (*CallsRepository, error) {
 	return r, nil
 }
 
-func (r *CallsRepository) GetCall(method string) (*core.CallRunConfig, bool) {
-	c, ok := r.calls[method]
-	return c, ok
+func (r *CallsRepository) GetCall(method string) *core.CallRunConfig {
+	return r.calls[method]
 }

--- a/pkg/repo/callrepo.go
+++ b/pkg/repo/callrepo.go
@@ -27,6 +27,11 @@ type CallsRepository struct {
 	calls map[string]*core.CallRunConfig
 }
 
+// NewCallsRepository initializes a new CallsRepository based on the provided CallsConfig.
+// It takes cfg of type *CallsConfig which contains the configuration for the calls.
+// It returns a pointer to CallsRepository and an error.
+// It returns an error if there is an issue parsing the request templates.
+// Edge cases include handling empty or nil CallsConfig, which will result in an empty CallsRepository.
 func NewCallsRepository(cfg *CallsConfig) (*CallsRepository, error) {
 	r := &CallsRepository{
 		calls: make(map[string]*core.CallRunConfig),

--- a/pkg/repo/callrepo_test.go
+++ b/pkg/repo/callrepo_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestNewCallsRepository(t *testing.T) {
 	tests := []struct {
-		name    string
 		cfg     *CallsConfig
+		name    string
 		wantErr bool
 	}{
 		{

--- a/pkg/repo/callrepo_test.go
+++ b/pkg/repo/callrepo_test.go
@@ -1,0 +1,133 @@
+package repo
+
+import (
+	"html/template"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCallsRepository(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     *CallsConfig
+		wantErr bool
+	}{
+		{
+			name: "valid config",
+			cfg: &CallsConfig{
+				Calls: []CallConfig{
+					{
+						Method: "testMethod",
+						Params: map[string]string{"param1": "value1"},
+						Backend: []BackendConfig{
+							{
+								FieldsMap:       map[string]string{"field1": "value1"},
+								ResponseBody:    "responseBody1",
+								RequestTemplate: "template1",
+								Allow:           []string{"allow1"},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid template",
+			cfg: &CallsConfig{
+				Calls: []CallConfig{
+					{
+						Method: "testMethod",
+						Params: map[string]string{"param1": "value1"},
+						Backend: []BackendConfig{
+							{
+								FieldsMap:       map[string]string{"field1": "value1"},
+								ResponseBody:    "responseBody1",
+								RequestTemplate: "{{.InvalidTemplate",
+								Allow:           []string{"allow1"},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewCallsRepository(tt.cfg)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, got)
+				assert.Contains(t, got.calls, "testMethod")
+
+				callConfig := got.calls["testMethod"]
+				assert.NotNil(t, callConfig)
+				assert.Contains(t, callConfig.Requests, "responseBody1")
+
+				requestConfig := callConfig.Requests["responseBody1"]
+				assert.NotNil(t, requestConfig)
+				assert.Equal(t, "responseBody1", requestConfig.ResponseBody)
+				assert.Equal(t, []string{"allow1"}, requestConfig.Allow)
+				assert.Equal(t, map[string]string{"field1": "value1"}, requestConfig.FieldMap)
+
+				tmpl, err := template.New("request").Parse("template1")
+				assert.NoError(t, err)
+				assert.Equal(t, tmpl.Tree.Root.String(), requestConfig.Tmplt.Tree.Root.String())
+			}
+		})
+	}
+}
+func TestGetCall(t *testing.T) {
+	repo, err := NewCallsRepository(&CallsConfig{
+		Calls: []CallConfig{
+			{
+				Method: "testMethod",
+				Params: map[string]string{"param1": "value1"},
+				Backend: []BackendConfig{
+					{
+						FieldsMap:       map[string]string{"field1": "value1"},
+						ResponseBody:    "responseBody1",
+						RequestTemplate: "template1",
+						Allow:           []string{"allow1"},
+					},
+				},
+			},
+		},
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, repo)
+
+	tests := []struct {
+		name   string
+		method string
+		found  bool
+	}{
+		{
+			name:   "existing method",
+			method: "testMethod",
+			found:  true,
+		},
+		{
+			name:   "non-existing method",
+			method: "nonExistingMethod",
+			found:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			callConfig := repo.GetCall(tt.method)
+
+			if tt.found {
+				assert.NotNil(t, callConfig)
+			} else {
+				assert.Nil(t, callConfig)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request refactors the calls management logic by moving it to the repo class. It also introduces a new CallsRepo interface and a CallsRepository implementation. The CallsRepository is responsible for parsing the configuration and creating the necessary data structures for handling calls and requests. The CallHandler now uses the CallsRepo interface to retrieve the call configuration and process requests accordingly. This refactoring improves code organization and separation of concerns.

Intend of this change to provide possibility in future reload calls configuration on the fly. 