### PR TITLE
Refactor logger initialization to support custom log level and log format

### DIFF
--- a/cmd/bff/main.go
+++ b/cmd/bff/main.go
@@ -10,11 +10,15 @@ import (
 	"github.com/ksysoev/deriv-api-bff/pkg/cmd"
 )
 
+// version is the version of the application. It should be set at build time.
+var version = "dev"
+var name = "deriv-api-bff"
+
 func main() {
 	ctx := context.Background()
 	ctx, cancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 
-	rootCmd := cmd.InitCommands()
+	rootCmd := cmd.InitCommands(name, version)
 
 	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		slog.Error("failed to execute command", slog.Any("error", err))

--- a/pkg/cmd/cfg.go
+++ b/pkg/cmd/cfg.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/ksysoev/deriv-api-bff/pkg/api"
@@ -34,6 +35,8 @@ func initConfig(configPath string) (*config, error) {
 	if err := viper.Unmarshal(cfg); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 	}
+
+	slog.Debug("Config loaded", slog.Any("config", cfg))
 
 	return cfg, nil
 }

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -8,8 +8,8 @@ type args struct {
 	appName    string
 	version    string
 	logLevel   string
-	textFormat bool
 	configPath string
+	textFormat bool
 }
 
 // InitCommands initializes and returns the root command for the Backend for Frontend (BFF) service.

--- a/pkg/cmd/logger.go
+++ b/pkg/cmd/logger.go
@@ -8,8 +8,28 @@ import (
 // initLogger initializes the default logger for the application using slog.
 // It does not take any parameters.
 // It returns an error if the logger initialization fails, although in this implementation, it always returns nil.
-func initLogger() error {
-	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{}))
+func initLogger(arg *args) error {
+	var logLever slog.Level
+	if err := logLever.UnmarshalText([]byte(arg.logLevel)); err != nil {
+		return err
+	}
+
+	options := &slog.HandlerOptions{
+		Level: logLever,
+	}
+
+	var logHandler slog.Handler
+	if arg.textFormat {
+		logHandler = slog.NewTextHandler(os.Stdout, options)
+	} else {
+		logHandler = slog.NewJSONHandler(os.Stdout, options)
+	}
+
+	logger := slog.New(logHandler).With(
+		slog.String("ver", arg.version),
+		slog.String("app", arg.appName),
+	)
+
 	slog.SetDefault(logger)
 
 	return nil


### PR DESCRIPTION
This pull request refactors the logger initialization to support custom log level and log format. It introduces a new `args` struct that holds the application name, version, log level, log format, and config path. The `InitCommands` function now takes the `name` and `version` as parameters and initializes the `args` struct. The `ServerCommand` function now takes the `arg` struct as a parameter and initializes the logger based on the log level and log format specified in the `args` struct. The `initLogger` function now takes the `arg` struct as a parameter and initializes the logger with the specified log level and log format.