### PR TITLE
Add version info to Docker image build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,11 @@ permissions:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+          - amd64
+          - arm64
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -43,7 +48,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/${{ matrix.platform }}
           build-args: |
             VERSION=${{ env.VERSION }}
             BUILD=${{ github.sha }}
-            ARCH=amd64
+            ARCH=${{ matrix.platform }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,9 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ghcr.io/${{ github.repository }}
-
+      - name: Extract version from tag
+        id: extract_version
+        run: echo "VERSION=$(echo ${{ steps.meta.outputs.tags }} | cut -d ':' -f 2)" >> $GITHUB_ENV
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
@@ -42,6 +44,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            VERSION=${{ steps.meta.outputs.tags }}
+            VERSION=${{ env.VERSION }}
             BUILD=${{ github.sha }}
             ARCH=amd64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,10 +1,10 @@
 name: Build Docker image
 
 on:
-  workflow_run:
-    workflows: [Tests]
-    types:
-      - completed
+  push:
+    branches:
+      - main
+  pull_request:
 
 permissions:
   contents: read
@@ -41,3 +41,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.meta.outputs.tags }}
+            BUILD=${{ github.sha }}
+            ARCH=amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM golang:1.23 AS builder
 
+ARG VERSION=${VERSION}
+ARG BUILD=${BUILD}
+ARG ARCH=${ARCH}
+
 WORKDIR /app/
 
 COPY . .
@@ -7,12 +11,13 @@ COPY . .
 RUN go mod download
 RUN go mod verify
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /main ./cmd/bff
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -o /deriv-api-bff  -ldflags "-X main.version=$VERSION -X main.build=$BUILD" ./cmd/bff
 
 FROM scratch
 
-COPY --from=builder /main /main
+COPY --from=builder /deriv-api-bff /deriv-api-bff
 
 COPY --from=builder /app/runtime/config.yaml /runtime/config.yaml
 
-ENTRYPOINT [ "./main", "server" ]
+ENTRYPOINT [ "./deriv-api-bff" ]
+CMD [ "server" ]

--- a/cmd/bff/main.go
+++ b/cmd/bff/main.go
@@ -12,13 +12,13 @@ import (
 
 // version is the version of the application. It should be set at build time.
 var version = "dev"
-var name = "deriv-api-bff"
+var build = "dev"
 
 func main() {
 	ctx := context.Background()
 	ctx, cancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 
-	rootCmd := cmd.InitCommands(name, version)
+	rootCmd := cmd.InitCommands(build, version)
 
 	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		slog.Error("failed to execute command", slog.Any("error", err))

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -1,11 +1,13 @@
 package cmd
 
 import (
+	"log/slog"
+
 	"github.com/spf13/cobra"
 )
 
 type args struct {
-	appName    string
+	build      string
 	version    string
 	logLevel   string
 	configPath string
@@ -15,9 +17,9 @@ type args struct {
 // InitCommands initializes and returns the root command for the Backend for Frontend (BFF) service.
 // It sets up the command structure and adds subcommands, including setting up persistent flags.
 // It returns a pointer to a cobra.Command which represents the root command.
-func InitCommands(name, version string) *cobra.Command {
+func InitCommands(build, version string) *cobra.Command {
 	args := &args{
-		appName: name,
+		build:   build,
 		version: version,
 	}
 
@@ -49,6 +51,8 @@ func ServerCommand(arg *args) *cobra.Command {
 			if err := initLogger(arg); err != nil {
 				return err
 			}
+
+			slog.Info("Starting Deriv API BFF server", slog.String("version", arg.version), slog.String("build", arg.build))
 
 			cfg, err := initConfig(arg.configPath)
 			if err != nil {

--- a/pkg/cmd/logger.go
+++ b/pkg/cmd/logger.go
@@ -27,7 +27,7 @@ func initLogger(arg *args) error {
 
 	logger := slog.New(logHandler).With(
 		slog.String("ver", arg.version),
-		slog.String("app", arg.appName),
+		slog.String("app", "deriv-api-bff"),
 	)
 
 	slog.SetDefault(logger)


### PR DESCRIPTION
This pull request adds version information to the Docker image build process. The version, build, and architecture are now included as build arguments. The main.go file has been updated to use the build information when initializing the server. Additionally, the logger now includes the application name as "deriv-api-bff".