### PR TITLE
Refactor Docker workflow to include tags starting with 'v' in build-and-push job

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - v*
   pull_request:
 
 permissions:


### PR DESCRIPTION
This pull request refactors the Docker workflow to include tags starting with 'v' in the build-and-push job. This ensures that only tags starting with 'v' are considered for the build and push process.