### PR TITLE
Add unit tests for processor package

### DIFF
--- a/pkg/core/processor/processor_test.go
+++ b/pkg/core/processor/processor_test.go
@@ -8,6 +8,28 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestNew(t *testing.T) {
+	tmpl, err := template.New("test").Parse("Params: {{.Params}}, ReqID: {{.ReqID}}")
+	if err != nil {
+		t.Fatalf("failed to parse template: %v", err)
+	}
+
+	cfg := &Config{
+		Tmplt:        tmpl,
+		FieldMap:     map[string]string{"key1": "mappedKey1"},
+		ResponseBody: "data",
+		Allow:        []string{"key1", "key2"},
+	}
+
+	processor := New(cfg)
+
+	assert.NotNil(t, processor)
+	assert.Equal(t, tmpl, processor.tmpl)
+	assert.Equal(t, cfg.FieldMap, processor.fieldMap)
+	assert.Equal(t, cfg.ResponseBody, processor.responseBody)
+	assert.Equal(t, cfg.Allow, processor.allow)
+}
+
 func TestProcessor_Render(t *testing.T) {
 	tmpl, err := template.New("test").Parse("Params: {{.Params}}, ReqID: {{.ReqID}}")
 	if err != nil {

--- a/pkg/core/processor/processor_test.go
+++ b/pkg/core/processor/processor_test.go
@@ -3,11 +3,12 @@ package processor
 import (
 	"bytes"
 	"html/template"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestRequestProcessor_Render(t *testing.T) {
+func TestProcessor_Render(t *testing.T) {
 	tmpl, err := template.New("test").Parse("Params: {{.Params}}, ReqID: {{.ReqID}}")
 	if err != nil {
 		t.Fatalf("failed to parse template: %v", err)
@@ -23,34 +24,52 @@ func TestRequestProcessor_Render(t *testing.T) {
 
 	var buf bytes.Buffer
 
-	if err := rp.Render(&buf, int64(reqID), params); err != nil {
-		t.Fatalf("expected no error, got %v", err)
+	err = rp.Render(&buf, int64(reqID), params)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, buf.String())
+}
+
+func TestProcessor_parse_Success(t *testing.T) {
+	tests := []struct {
+		name         string
+		responseBody string
+		jsonData     string
+		expected     map[string]any
+	}{
+		{
+			name:         "object",
+			responseBody: "data",
+			jsonData:     `{"data": {"key1": "value1", "key2": "value2"}}`,
+			expected:     map[string]any{"key1": "value1", "key2": "value2"},
+		},
+		{
+			name:         "array",
+			responseBody: "data",
+			jsonData:     `{"data": [{"key1": "value1"}, {"key2": "value2"}]}`,
+			expected:     map[string]any{"list": []any{map[string]any{"key1": "value1"}, map[string]any{"key2": "value2"}}},
+		},
+		{
+			name:         "scalar",
+			responseBody: "data",
+			jsonData:     `{"data": "value"}`,
+			expected:     map[string]any{"value": "value"},
+		},
 	}
 
-	if buf.String() != expected {
-		t.Fatalf("expected %s, got %s", expected, buf.String())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rp := &Processor{
+				responseBody: tt.responseBody,
+			}
+
+			result, err := rp.parse([]byte(tt.jsonData))
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
 	}
 }
 
-func TestRequestProcessor_parse_Success(t *testing.T) {
-	rp := &Processor{
-		responseBody: "data",
-	}
-
-	jsonData := `{"data": {"key1": "value1", "key2": "value2"}}`
-	expected := map[string]any{"key1": "value1", "key2": "value2"}
-
-	result, err := rp.parse([]byte(jsonData))
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-
-	if !reflect.DeepEqual(result, expected) {
-		t.Fatalf("expected %v, got %v", expected, result)
-	}
-}
-
-func TestRequestProcessor_parse_Error(t *testing.T) {
+func TestProcessor_parse_Error(t *testing.T) {
 	rp := &Processor{
 		responseBody: "data",
 	}
@@ -58,25 +77,28 @@ func TestRequestProcessor_parse_Error(t *testing.T) {
 	jsonData := `{"error": "something went wrong"}`
 
 	_, err := rp.parse([]byte(jsonData))
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
+	assert.Error(t, err)
 }
 
-func TestRequestProcessor_parse_UnexpectedFormat(t *testing.T) {
+func TestProcessor_parse_ResponseBodyNotFound(t *testing.T) {
 	rp := &Processor{
 		responseBody: "data",
 	}
 
-	jsonData := `{"data": 123}`
+	jsonData := `{"key": "value"}`
+
+	_, err := rp.parse([]byte(jsonData))
+	assert.Error(t, err)
+}
+
+func TestProcessor_parse_UnexpectedFormat(t *testing.T) {
+	rp := &Processor{
+		responseBody: "data",
+	}
+
+	jsonData := `{invalid json}`
 
 	result, err := rp.parse([]byte(jsonData))
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-
-	expected := map[string]any{"value": 123.0} // go will parse string numerics to float64
-	if !reflect.DeepEqual(result, expected) {
-		t.Fatalf("expected %v, got %v", expected, result)
-	}
+	assert.Error(t, err)
+	assert.Nil(t, result)
 }

--- a/pkg/core/processor/processor_test.go
+++ b/pkg/core/processor/processor_test.go
@@ -53,10 +53,10 @@ func TestProcessor_Render(t *testing.T) {
 
 func TestProcessor_parse_Success(t *testing.T) {
 	tests := []struct {
+		expected     map[string]any
 		name         string
 		responseBody string
 		jsonData     string
-		expected     map[string]any
 	}{
 		{
 			name:         "object",
@@ -126,12 +126,12 @@ func TestProcessor_parse_UnexpectedFormat(t *testing.T) {
 }
 func TestProcessor_Parse_Success(t *testing.T) {
 	tests := []struct {
+		fieldMap     map[string]string
+		expected     map[string]any
 		name         string
 		responseBody string
-		fieldMap     map[string]string
-		allow        []string
 		jsonData     string
-		expected     map[string]any
+		allow        []string
 	}{
 		{
 			name:         "allowed fields with field mapping",


### PR DESCRIPTION
This pull request adds unit tests for the processor package. The tests cover the parse method, the processor constructor, and the Render method. The tests ensure that the processor functions as expected and that the parse method correctly handles different JSON formats. The addition of these tests improves the overall test coverage and helps to ensure the reliability and correctness of the processor package.

Contributes to #17 