### PR TITLE
Add tests for cmd package

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
         run: go test -coverprofile=coverage.out -covermode=atomic -v -race ./...
       - name: Prepare coverage reports
         run: |
-          cat coverage.out | grep -v "_mock.go" > coverage.final.out
+          cat coverage.out | grep -v "deriv-api-bff/cmd" | grep -v "_mock.go" > coverage.final.out
           mv coverage.final.out coverage.out
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4

--- a/pkg/cmd/cfg_test.go
+++ b/pkg/cmd/cfg_test.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var validConfig = `
+server:
+  listen: ":0"
+deriv:
+  endpoint: "wss://localhost/"
+api:
+`
+
+var invalidConfig = `
+server:
+  listen: 123
+`
+
+func createTempConfigFile(t *testing.T, content string) string {
+	tmpdir := os.TempDir()
+	configPath := tmpdir + "/test_config.yaml"
+
+	err := os.WriteFile(configPath, []byte(content), 0644)
+	assert.NoError(t, err)
+
+	t.Cleanup(func() {
+		os.Remove(configPath)
+	})
+
+	return configPath
+}
+
+func TestInitConfig_Valid(t *testing.T) {
+	configPath := createTempConfigFile(t, validConfig)
+
+	cfg, err := initConfig(configPath)
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
+	assert.Equal(t, ":0", cfg.Server.Listen)
+	assert.Equal(t, "wss://localhost/", cfg.Deriv.Endpoint)
+}
+
+func TestInitConfig_InvalidContent(t *testing.T) {
+	configPath := createTempConfigFile(t, "invalid content")
+
+	cfg, err := initConfig(configPath)
+	assert.Error(t, err)
+	assert.Nil(t, cfg)
+}
+
+func TestInitConfig_Missing(t *testing.T) {
+	dir := os.TempDir()
+	configPath := dir + "/missing_config.yaml"
+
+	cfg, err := initConfig(configPath)
+	assert.Error(t, err)
+	assert.Nil(t, cfg)
+}

--- a/pkg/cmd/cfg_test.go
+++ b/pkg/cmd/cfg_test.go
@@ -15,16 +15,13 @@ deriv:
 api:
 `
 
-var invalidConfig = `
-server:
-  listen: 123
-`
-
 func createTempConfigFile(t *testing.T, content string) string {
+	t.Helper()
+
 	tmpdir := os.TempDir()
 	configPath := tmpdir + "/test_config.yaml"
 
-	err := os.WriteFile(configPath, []byte(content), 0644)
+	err := os.WriteFile(configPath, []byte(content), 0o600)
 	assert.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/pkg/cmd/init_test.go
+++ b/pkg/cmd/init_test.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitCommands(t *testing.T) {
+	build := "test-build"
+	version := "test-version"
+
+	cmd := InitCommands(build, version)
+
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "bff", cmd.Use)
+	assert.Equal(t, "Backend for Frontend service", cmd.Short)
+	assert.Equal(t, "Backend for Frontend service for Deriv API", cmd.Long)
+
+	configFlag := cmd.PersistentFlags().Lookup("config")
+	assert.NotNil(t, configFlag)
+	assert.Equal(t, "./runtime/config.yaml", configFlag.DefValue)
+
+	logLevelFlag := cmd.PersistentFlags().Lookup("log-level")
+	assert.NotNil(t, logLevelFlag)
+	assert.Equal(t, "info", logLevelFlag.DefValue)
+
+	logTextFlag := cmd.PersistentFlags().Lookup("log-text")
+	assert.NotNil(t, logTextFlag)
+	assert.Equal(t, "false", logTextFlag.DefValue)
+
+	subCommands := cmd.Commands()
+	assert.Equal(t, 1, len(subCommands))
+	assert.Equal(t, "server", subCommands[0].Use)
+}
+
+func TestServerCommand(t *testing.T) {
+	configPath := createTempConfigFile(t, validConfig)
+
+	arg := &args{
+		build:      "test-build",
+		version:    "test-version",
+		configPath: configPath,
+		logLevel:   "debug",
+		textFormat: true,
+	}
+
+	cmd := ServerCommand(arg)
+
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "server", cmd.Use)
+	assert.Equal(t, "Start BFF server", cmd.Short)
+	assert.Equal(t, "Start BFF server for Deriv API", cmd.Long)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := cmd.ExecuteContext(ctx)
+
+	assert.NoError(t, err)
+}

--- a/pkg/cmd/logger_test.go
+++ b/pkg/cmd/logger_test.go
@@ -43,8 +43,9 @@ func TestInitLogger(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			args := tt.arg
+			err := initLogger(&args)
 
-			err := initLogger(&tt.arg)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/pkg/cmd/logger_test.go
+++ b/pkg/cmd/logger_test.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitLogger(t *testing.T) {
+	tests := []struct {
+		name    string
+		arg     args
+		wantErr bool
+	}{
+		{
+			name: "Valid log level with text format",
+			arg: args{
+				logLevel:   "info",
+				textFormat: true,
+				version:    "1.0.0",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid log level with JSON format",
+			arg: args{
+				logLevel:   "debug",
+				textFormat: false,
+				version:    "1.0.0",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid log level",
+			arg: args{
+				logLevel:   "invalid",
+				textFormat: true,
+				version:    "1.0.0",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			err := initLogger(&tt.arg)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/cmd/server_test.go
+++ b/pkg/cmd/server_test.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ksysoev/deriv-api-bff/pkg/api"
+	"github.com/ksysoev/deriv-api-bff/pkg/core/validator"
+	"github.com/ksysoev/deriv-api-bff/pkg/repo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunServer(t *testing.T) {
+	cfg := &config{
+		Server: api.Config{
+			Listen: ":0",
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := runServer(ctx, cfg)
+
+	assert.NoError(t, err)
+}
+
+func TestRunServer_Error(t *testing.T) {
+	cfg := &config{
+		Server: api.Config{
+			Listen: ":0",
+		},
+		API: repo.CallsConfig{
+			Calls: []repo.CallConfig{
+				{
+					Method: "GET",
+					Params: validator.Config{
+						"param": &validator.FieldSchema{
+							Type: "InvalidType",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := runServer(ctx, cfg)
+
+	assert.Error(t, err)
+}


### PR DESCRIPTION
This pull request adds tests for the `cmd` package. The tests cover the `initConfig`, `initCommands`, `serverCommand`, and `initLogger` functions. The tests ensure that the functions are working correctly and handle different scenarios, such as valid and invalid configurations, missing files, and different log levels and formats.

contributes to #17 