### PR TITLE
Refactor Request struct and createResponse function

### DIFF
--- a/pkg/core/request.go
+++ b/pkg/core/request.go
@@ -13,11 +13,12 @@ const (
 )
 
 type Request struct {
-	ctx    context.Context
-	Params map[string]any `json:"params"`
-	ID     *int           `json:"req_id"`
-	Method string         `json:"method"`
-	data   []byte
+	ctx         context.Context
+	Params      map[string]any `json:"params"`
+	ID          *int           `json:"req_id"`
+	Method      string         `json:"method"`
+	PassThrough any            `json:"passthrough"`
+	data        []byte
 }
 
 // NewRequest creates a new Request object based on the provided message type and data.

--- a/pkg/core/response.go
+++ b/pkg/core/response.go
@@ -1,0 +1,35 @@
+package core
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+func createRespose(req *Request, resp map[string]any, err error) ([]byte, error) {
+	var apiErr *APIError
+
+	if errors.As(err, &apiErr) {
+		resp = make(map[string]any)
+		resp["error"] = apiErr.Encode()
+	} else if err != nil {
+		return nil, fmt.Errorf("failed to handle request: %w", err)
+	}
+
+	if req.ID != nil {
+		resp["req_id"] = *req.ID
+	}
+
+	if req.PassThrough != nil {
+		resp["passthrough"] = req.PassThrough
+	}
+
+	resp["echo"] = json.RawMessage(req.Data())
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal response: %w", err)
+	}
+
+	return data, nil
+}

--- a/pkg/core/svc.go
+++ b/pkg/core/svc.go
@@ -2,8 +2,6 @@ package core
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
 
 	"github.com/ksysoev/wasabi"
@@ -81,22 +79,9 @@ func (s *Service) ProcessRequest(clientConn wasabi.Connection, req *Request) err
 		},
 	)
 
-	var apiErr *APIError
-
-	if errors.As(err, &apiErr) {
-		resp = make(map[string]any)
-		resp["error"] = apiErr.Encode()
-	} else if err != nil {
-		return fmt.Errorf("failed to handle request: %w", err)
-	}
-
-	if req.ID != nil {
-		resp["req_id"] = *req.ID
-	}
-
-	data, err := json.Marshal(resp)
+	data, err := createRespose(req, resp, err)
 	if err != nil {
-		return fmt.Errorf("failed to marshal response: %w", err)
+		return err
 	}
 
 	return clientConn.Send(wasabi.MsgTypeText, data)


### PR DESCRIPTION
This pull request refactors the Request struct and adds a new function called createResponse. The Request struct now includes a new field called PassThrough. The createResponse function handles the creation of the response for a request. It checks for any API errors and encodes them in the response. It also includes the request ID and the passthrough data in the response. The function then marshals the response into JSON format. This refactoring improves the code structure and makes the response handling more modular.