### PR TITLE
Refactor Dockerfile and docker-compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,9 @@ RUN CGO_ENABLED=0 go build -o /deriv-api-bff  -ldflags "-X main.version=$VERSION
 FROM scratch
 
 COPY --from=builder /deriv-api-bff /deriv-api-bff
-
 COPY --from=builder /app/runtime/config.yaml /runtime/config.yaml
+
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 ENTRYPOINT [ "./deriv-api-bff" ]
 CMD [ "server", "--config=./runtime/config.yaml" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23 AS builder
+FROM golang:1.23.1 AS builder
 
 ARG VERSION=${VERSION}
 ARG BUILD=${BUILD}
@@ -19,4 +19,4 @@ COPY --from=builder /deriv-api-bff /deriv-api-bff
 COPY --from=builder /app/runtime/config.yaml /runtime/config.yaml
 
 ENTRYPOINT [ "./deriv-api-bff" ]
-CMD [ "server" ]
+CMD [ "server", "--config=./runtime/config.yaml" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,16 @@
-version: '3.8'
-
 services:
   deriv-api-bff:
-    image: ${IMAGE_NAME}:${IMAGE_TAG}
-    container_name: ${CONTAINER_NAME}
-    restart: unless-stopped
+    image: ghcr.io/ksysoev/deriv-api-bff:main
+    build: 
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - VERSION=dev
+        - BUILD=dev
+    container_name: deriv-api-bff
     ports:
-      - "${HOST_PORT}:${HOST_PORT}"
+      - "8082:8082"
     environment:
-      - GLOBAL_DEBUG_ON=${GLOBAL_DEBUG_ON}
+      - SERVER_LISTEN=:8082
+    command: ["server", "--config", "/runtime/config.yaml", "--log-level=debug", "--log-text"]
+    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,16 @@ services:
         - BUILD=dev
     container_name: deriv-api-bff
     ports:
-      - "8082:8082"
+      - "8080:8080"
     environment:
-      - SERVER_LISTEN=:8082
-    command: ["server", "--config", "/runtime/config.yaml", "--log-level=debug", "--log-text"]
+      - SERVER_LISTEN=:8080
+    volumes:
+      - ./runtime/config.yaml:/runtime/config.yaml
+    command: [
+      "server", 
+      "--config", 
+      "/runtime/config.yaml", 
+      "--log-level=debug", 
+      "--log-text"
+      ]
     


### PR DESCRIPTION
Refactor the Dockerfile to use the golang:1.23.1 base image and update the CMD to include the config file path. Also, modify the docker-compose.yml to use the latest image from the repository, adjust the container name and port mapping, and set the server listen address to :8080.