### PR TITLE
Add support for defining command line arguments with environment variables

### DIFF
--- a/cmd/bff/main.go
+++ b/cmd/bff/main.go
@@ -18,7 +18,12 @@ func main() {
 	ctx := context.Background()
 	ctx, cancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 
-	rootCmd := cmd.InitCommands(build, version)
+	rootCmd, err := cmd.InitCommands(build, version)
+	if err != nil {
+		slog.Error("failed to initialize commands", slog.Any("error", err))
+		cancel()
+		os.Exit(1)
+	}
 
 	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		slog.Error("failed to execute command", slog.Any("error", err))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,8 @@ services:
       - "8080:8080"
     environment:
       - SERVER_LISTEN=:8090
-      - LOG_LEVEL=debug
-      - LOG_TEXT=true
+      - LOGLEVEL=debug
+      - LOGTEXT=true
     volumes:
       - ./runtime/config.yaml:/runtime/config.yaml
     command: [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,14 +11,14 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - SERVER_LISTEN=:8080
+      - SERVER_LISTEN=:8090
+      - LOG_LEVEL=debug
+      - LOG_TEXT=true
     volumes:
       - ./runtime/config.yaml:/runtime/config.yaml
     command: [
       "server", 
       "--config", 
       "/runtime/config.yaml", 
-      "--log-level=debug", 
-      "--log-text"
       ]
     

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -11,9 +11,9 @@ import (
 type args struct {
 	build      string
 	version    string
-	LogLevel   string `mapstructure:"LOG_LEVEL"`
-	ConfigPath string `mapstructure:"CONFIG"`
-	TextFormat bool   `mapstructure:"LOG_TEXT"`
+	LogLevel   string `mapstructure:"loglevel"`
+	ConfigPath string `mapstructure:"config"`
+	TextFormat bool   `mapstructure:"logtext"`
 }
 
 // InitCommands initializes and returns the root command for the Backend for Frontend (BFF) service.
@@ -34,19 +34,11 @@ func InitCommands(build, version string) (*cobra.Command, error) {
 	cmd.AddCommand(ServerCommand(args))
 
 	cmd.PersistentFlags().StringVar(&args.ConfigPath, "config", "./runtime/config.yaml", "config file path")
-	cmd.PersistentFlags().StringVar(&args.LogLevel, "log-level", "info", "log level (debug, info, warn, error)")
-	cmd.PersistentFlags().BoolVar(&args.TextFormat, "log-text", false, "log in text format, otherwise JSON")
+	cmd.PersistentFlags().StringVar(&args.LogLevel, "loglevel", "info", "log level (debug, info, warn, error)")
+	cmd.PersistentFlags().BoolVar(&args.TextFormat, "logtext", false, "log in text format, otherwise JSON")
 
-	if err := viper.BindPFlag("LOG_LEVEL", cmd.PersistentFlags().Lookup("log-level")); err != nil {
-		return nil, fmt.Errorf("failed to bind log level flag: %w", err)
-	}
-
-	if err := viper.BindPFlag("LOG_TEXT", cmd.PersistentFlags().Lookup("log-text")); err != nil {
-		return nil, fmt.Errorf("failed to bind log text flag: %w", err)
-	}
-
-	if err := viper.BindPFlag("CONFIG", cmd.PersistentFlags().Lookup("config")); err != nil {
-		return nil, fmt.Errorf("failed to bind config flag: %w", err)
+	if err := viper.BindPFlags(cmd.PersistentFlags()); err != nil {
+		return nil, fmt.Errorf("failed to parse env args: %w", err)
 	}
 
 	viper.AutomaticEnv()

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -1,23 +1,25 @@
 package cmd
 
 import (
+	"fmt"
 	"log/slog"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 type args struct {
 	build      string
 	version    string
-	logLevel   string
-	configPath string
-	textFormat bool
+	LogLevel   string `mapstructure:"LOG_LEVEL"`
+	ConfigPath string `mapstructure:"CONFIG"`
+	TextFormat bool   `mapstructure:"LOG_TEXT"`
 }
 
 // InitCommands initializes and returns the root command for the Backend for Frontend (BFF) service.
 // It sets up the command structure and adds subcommands, including setting up persistent flags.
 // It returns a pointer to a cobra.Command which represents the root command.
-func InitCommands(build, version string) *cobra.Command {
+func InitCommands(build, version string) (*cobra.Command, error) {
 	args := &args{
 		build:   build,
 		version: version,
@@ -31,11 +33,29 @@ func InitCommands(build, version string) *cobra.Command {
 
 	cmd.AddCommand(ServerCommand(args))
 
-	cmd.PersistentFlags().StringVar(&args.configPath, "config", "./runtime/config.yaml", "config file path")
-	cmd.PersistentFlags().StringVar(&args.logLevel, "log-level", "info", "log level (debug, info, warn, error)")
-	cmd.PersistentFlags().BoolVar(&args.textFormat, "log-text", false, "log in text format, otherwise JSON")
+	cmd.PersistentFlags().StringVar(&args.ConfigPath, "config", "./runtime/config.yaml", "config file path")
+	cmd.PersistentFlags().StringVar(&args.LogLevel, "log-level", "info", "log level (debug, info, warn, error)")
+	cmd.PersistentFlags().BoolVar(&args.TextFormat, "log-text", false, "log in text format, otherwise JSON")
 
-	return cmd
+	if err := viper.BindPFlag("LOG_LEVEL", cmd.PersistentFlags().Lookup("log-level")); err != nil {
+		return nil, fmt.Errorf("failed to bind log level flag: %w", err)
+	}
+
+	if err := viper.BindPFlag("LOG_TEXT", cmd.PersistentFlags().Lookup("log-text")); err != nil {
+		return nil, fmt.Errorf("failed to bind log text flag: %w", err)
+	}
+
+	if err := viper.BindPFlag("CONFIG", cmd.PersistentFlags().Lookup("config")); err != nil {
+		return nil, fmt.Errorf("failed to bind config flag: %w", err)
+	}
+
+	viper.AutomaticEnv()
+
+	if err := viper.Unmarshal(args); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal args: %w", err)
+	}
+
+	return cmd, nil
 }
 
 // ServerCommand creates a new cobra.Command to start the BFF server for Deriv API.
@@ -54,7 +74,7 @@ func ServerCommand(arg *args) *cobra.Command {
 
 			slog.Info("Starting Deriv API BFF server", slog.String("version", arg.version), slog.String("build", arg.build))
 
-			cfg, err := initConfig(arg.configPath)
+			cfg, err := initConfig(arg.ConfigPath)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/init_test.go
+++ b/pkg/cmd/init_test.go
@@ -11,7 +11,8 @@ func TestInitCommands(t *testing.T) {
 	build := "test-build"
 	version := "test-version"
 
-	cmd := InitCommands(build, version)
+	cmd, err := InitCommands(build, version)
+	assert.NoError(t, err)
 
 	assert.NotNil(t, cmd)
 	assert.Equal(t, "bff", cmd.Use)
@@ -41,9 +42,9 @@ func TestServerCommand(t *testing.T) {
 	arg := &args{
 		build:      "test-build",
 		version:    "test-version",
-		configPath: configPath,
-		logLevel:   "debug",
-		textFormat: true,
+		ConfigPath: configPath,
+		LogLevel:   "debug",
+		TextFormat: true,
 	}
 
 	cmd := ServerCommand(arg)

--- a/pkg/cmd/logger.go
+++ b/pkg/cmd/logger.go
@@ -10,7 +10,7 @@ import (
 // It returns an error if the logger initialization fails, although in this implementation, it always returns nil.
 func initLogger(arg *args) error {
 	var logLever slog.Level
-	if err := logLever.UnmarshalText([]byte(arg.logLevel)); err != nil {
+	if err := logLever.UnmarshalText([]byte(arg.LogLevel)); err != nil {
 		return err
 	}
 
@@ -19,7 +19,7 @@ func initLogger(arg *args) error {
 	}
 
 	var logHandler slog.Handler
-	if arg.textFormat {
+	if arg.TextFormat {
 		logHandler = slog.NewTextHandler(os.Stdout, options)
 	} else {
 		logHandler = slog.NewJSONHandler(os.Stdout, options)

--- a/pkg/cmd/logger_test.go
+++ b/pkg/cmd/logger_test.go
@@ -15,8 +15,8 @@ func TestInitLogger(t *testing.T) {
 		{
 			name: "Valid log level with text format",
 			arg: args{
-				logLevel:   "info",
-				textFormat: true,
+				LogLevel:   "info",
+				TextFormat: true,
 				version:    "1.0.0",
 			},
 			wantErr: false,
@@ -24,8 +24,8 @@ func TestInitLogger(t *testing.T) {
 		{
 			name: "Valid log level with JSON format",
 			arg: args{
-				logLevel:   "debug",
-				textFormat: false,
+				LogLevel:   "debug",
+				TextFormat: false,
 				version:    "1.0.0",
 			},
 			wantErr: false,
@@ -33,8 +33,8 @@ func TestInitLogger(t *testing.T) {
 		{
 			name: "Invalid log level",
 			arg: args{
-				logLevel:   "invalid",
-				textFormat: true,
+				LogLevel:   "invalid",
+				TextFormat: true,
 				version:    "1.0.0",
 			},
 			wantErr: true,


### PR DESCRIPTION
This pull request adds the ability to define command line arguments using environment variables. It also includes updates to the configuration file and logger initialization to support this feature.