### PR TITLE
Fix incorrect port in docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - SERVER_LISTEN=:8090
+      - SERVER_LISTEN=:8080
       - LOGLEVEL=debug
       - LOGTEXT=true
     volumes:


### PR DESCRIPTION
This pull request fixes an incorrect port in the docker-compose file. The port was mistakenly set to 8090 instead of the correct port 8080. The patch in the pull request corrects this error by updating the port to the correct value.