### PR TITLE
Implement removal of outdated etcd keys and add tests

### DIFF
--- a/pkg/config/source/etcd_source.go
+++ b/pkg/config/source/etcd_source.go
@@ -120,6 +120,7 @@ func (es *EtcdSource) PutConfig(ctx context.Context, cfg []handlerfactory.Config
 		if _, ok := indx[key]; !ok {
 			ctx, cancel := context.WithTimeout(ctx, defaultTimeoutSeconds*time.Second)
 			_, err := es.cli.Delete(ctx, string(kv.Key))
+
 			cancel()
 
 			if err != nil {

--- a/pkg/config/source/etcd_source_test.go
+++ b/pkg/config/source/etcd_source_test.go
@@ -21,7 +21,7 @@ func TestEtcdSource_Int(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	ctr, err := etcd.Run(ctx, "gcr.io/etcd-development/etcd:v3.5.14", etcd.WithNodes("etcd-1", "etcd-2", "etcd-3"))
+	ctr, err := etcd.Run(ctx, "gcr.io/etcd-development/etcd:v3.5.14", etcd.WithNodes("etcd-1", "etcd-2"))
 	testcontainers.CleanupContainer(t, ctr)
 	require.NoError(t, err)
 
@@ -123,4 +123,30 @@ func TestEtcdSource_Int(t *testing.T) {
 	configs, err = source.LoadConfig(ctx)
 	assert.Error(t, err, "failed to load config")
 	assert.Nil(t, configs)
+
+	expected = []handlerfactory.Config{
+		{
+			Method: "Test2",
+			Backend: []*processor.Config{
+				{
+					Tmplt: map[string]any{"ping": "pong"},
+				},
+			},
+		},
+		{
+			Method: "Test3",
+			Backend: []*processor.Config{
+				{
+					Tmplt: map[string]any{"ping": "pong"},
+				},
+			},
+		},
+	}
+
+	err = source.PutConfig(ctx, expected)
+	require.NoError(t, err)
+
+	configs, err = source.LoadConfig(ctx)
+	assert.NoError(t, err, "failed to load config")
+	assert.Equal(t, expected, configs)
 }

--- a/pkg/config/source/etcd_source_test.go
+++ b/pkg/config/source/etcd_source_test.go
@@ -17,7 +17,7 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
-func TestEtcdSource_Int(t *testing.T) {
+func TestEtcdSource_Integration(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
@@ -33,120 +33,162 @@ func TestEtcdSource_Int(t *testing.T) {
 	etcdHost, err := ctr.ClientEndpoints(ctx)
 	require.NoError(t, err)
 
-	_, err = NewEtcdSource(EtcdConfig{
-		Servers: "",
-		Prefix:  "",
-	})
-	assert.Error(t, err, "should fail to create etcd source")
-
-	source, err := NewEtcdSource(EtcdConfig{
-		Servers: "",
-		Prefix:  "test1::",
-	})
-	require.NoError(t, err)
-
-	configs, err := source.LoadConfig(ctx)
-
-	assert.Error(t, err, "failed to load config")
-	assert.Nil(t, configs)
-
-	err = source.PutConfig(ctx, []handlerfactory.Config{
-		{
-			Method: "Test",
-		},
-	})
-	assert.Error(t, err, "failed to put config")
-
-	source, err = NewEtcdSource(EtcdConfig{
-		Servers: strings.Join(etcdHost, ","),
-		Prefix:  "test2::",
+	t.Run("Fail to create etcd source with empty servers", func(t *testing.T) {
+		_, err := NewEtcdSource(EtcdConfig{
+			Servers: "",
+			Prefix:  "",
+		})
+		assert.Error(t, err, "should fail to create etcd source")
 	})
 
-	assert.NoError(t, err, "failed to create etcd source")
-	assert.NotNil(t, source)
+	t.Run("Fail to load config with empty servers", func(t *testing.T) {
+		source, err := NewEtcdSource(EtcdConfig{
+			Servers: "",
+			Prefix:  "test1::",
+		})
+		require.NoError(t, err)
 
-	configs, err = source.LoadConfig(ctx)
+		configs, err := source.LoadConfig(ctx)
+		assert.Error(t, err, "failed to load config")
+		assert.Nil(t, configs)
+	})
 
-	assert.NoError(t, err, "failed to load config")
-	assert.NotNil(t, configs)
-	assert.Len(t, configs, 0)
+	t.Run("Fail to put config with empty servers", func(t *testing.T) {
+		source, err := NewEtcdSource(EtcdConfig{
+			Servers: "",
+			Prefix:  "test1::",
+		})
+		require.NoError(t, err)
 
-	expected := []handlerfactory.Config{
-		{
-			Method: "Test",
-			Backend: []*processor.Config{
-				{
-					Tmplt: map[string]any{"ping": "pong"},
+		err = source.PutConfig(ctx, []handlerfactory.Config{
+			{
+				Method: "Test",
+			},
+		})
+		assert.Error(t, err, "failed to put config")
+	})
+
+	t.Run("Create etcd source with valid servers", func(t *testing.T) {
+		source, err := NewEtcdSource(EtcdConfig{
+			Servers: strings.Join(etcdHost, ","),
+			Prefix:  "test2::",
+		})
+		assert.NoError(t, err, "failed to create etcd source")
+		assert.NotNil(t, source)
+
+		configs, err := source.LoadConfig(ctx)
+		assert.NoError(t, err, "failed to load config")
+		assert.NotNil(t, configs)
+		assert.Len(t, configs, 0)
+	})
+
+	t.Run("Put and load valid config", func(t *testing.T) {
+		source, err := NewEtcdSource(EtcdConfig{
+			Servers: strings.Join(etcdHost, ","),
+			Prefix:  "test2::",
+		})
+		require.NoError(t, err)
+
+		expected := []handlerfactory.Config{
+			{
+				Method: "Test",
+				Backend: []*processor.Config{
+					{
+						Tmplt: map[string]any{"ping": "pong"},
+					},
 				},
 			},
-		},
-		{
-			Method: "Test2",
-			Backend: []*processor.Config{
-				{
-					Tmplt: map[string]any{"ping": "pong"},
+			{
+				Method: "Test2",
+				Backend: []*processor.Config{
+					{
+						Tmplt: map[string]any{"ping": "pong"},
+					},
 				},
 			},
-		},
-	}
+		}
 
-	err = source.PutConfig(ctx, expected)
-	require.NoError(t, err)
+		err = source.PutConfig(ctx, expected)
+		require.NoError(t, err)
 
-	configs, err = source.LoadConfig(ctx)
-
-	assert.NoError(t, err, "failed to load config")
-	assert.Equal(t, expected, configs)
-
-	err = source.PutConfig(ctx, []handlerfactory.Config{
-		{
-			Method: "Test",
-			Params: &validator.Config{"test": make(chan int)},
-			Backend: []*processor.Config{
-				{
-					Tmplt: map[string]any{"ping": "pong"},
-				},
-			},
-		},
+		configs, err := source.LoadConfig(ctx)
+		assert.NoError(t, err, "failed to load config")
+		assert.Equal(t, expected, configs)
 	})
-	assert.Error(t, err, "failed to marshal config")
 
-	etcdClient, err := clientv3.New(clientv3.Config{
-		Endpoints:   etcdHost,
-		DialTimeout: defaultTimeoutSeconds * time.Second,
+	t.Run("Fail to marshal invalid config", func(t *testing.T) {
+		source, err := NewEtcdSource(EtcdConfig{
+			Servers: strings.Join(etcdHost, ","),
+			Prefix:  "test2::",
+		})
+		require.NoError(t, err)
+
+		err = source.PutConfig(ctx, []handlerfactory.Config{
+			{
+				Method: "Test",
+				Params: &validator.Config{"test": make(chan int)},
+				Backend: []*processor.Config{
+					{
+						Tmplt: map[string]any{"ping": "pong"},
+					},
+				},
+			},
+		})
+		assert.Error(t, err, "failed to marshal config")
 	})
-	require.NoError(t, err)
 
-	_, err = etcdClient.Put(ctx, "test2::Test", "invalid json")
-	require.NoError(t, err)
+	t.Run("Fail to load invalid JSON config", func(t *testing.T) {
+		source, err := NewEtcdSource(EtcdConfig{
+			Servers: strings.Join(etcdHost, ","),
+			Prefix:  "test2::",
+		})
+		require.NoError(t, err)
 
-	configs, err = source.LoadConfig(ctx)
-	assert.Error(t, err, "failed to load config")
-	assert.Nil(t, configs)
+		etcdClient, err := clientv3.New(clientv3.Config{
+			Endpoints:   etcdHost,
+			DialTimeout: defaultTimeoutSeconds * time.Second,
+		})
+		require.NoError(t, err)
 
-	expected = []handlerfactory.Config{
-		{
-			Method: "Test2",
-			Backend: []*processor.Config{
-				{
-					Tmplt: map[string]any{"ping": "pong"},
+		_, err = etcdClient.Put(ctx, "test2::Test", "invalid json")
+		require.NoError(t, err)
+
+		configs, err := source.LoadConfig(ctx)
+		assert.Error(t, err, "failed to load config")
+		assert.Nil(t, configs)
+	})
+
+	t.Run("Put and load another valid config", func(t *testing.T) {
+		source, err := NewEtcdSource(EtcdConfig{
+			Servers: strings.Join(etcdHost, ","),
+			Prefix:  "test2::",
+		})
+		require.NoError(t, err)
+
+		expected := []handlerfactory.Config{
+			{
+				Method: "Test2",
+				Backend: []*processor.Config{
+					{
+						Tmplt: map[string]any{"ping": "pong"},
+					},
 				},
 			},
-		},
-		{
-			Method: "Test3",
-			Backend: []*processor.Config{
-				{
-					Tmplt: map[string]any{"ping": "pong"},
+			{
+				Method: "Test3",
+				Backend: []*processor.Config{
+					{
+						Tmplt: map[string]any{"ping": "pong"},
+					},
 				},
 			},
-		},
-	}
+		}
 
-	err = source.PutConfig(ctx, expected)
-	require.NoError(t, err)
+		err = source.PutConfig(ctx, expected)
+		require.NoError(t, err)
 
-	configs, err = source.LoadConfig(ctx)
-	assert.NoError(t, err, "failed to load config")
-	assert.Equal(t, expected, configs)
+		configs, err := source.LoadConfig(ctx)
+		assert.NoError(t, err, "failed to load config")
+		assert.Equal(t, expected, configs)
+	})
 }


### PR DESCRIPTION
Introduce logic to remove outdated keys from etcd when configurations are updated, along with corresponding tests to ensure functionality.