### PR TITLE
Implement skipping metrics for passthrough requests

### DIFF
--- a/pkg/api/svc.go
+++ b/pkg/api/svc.go
@@ -49,14 +49,6 @@ func NewSevice(cfg *Config, handler BFFService) *Service {
 
 	populateDefaults(cfg)
 
-	skipMetrics := func(r wasabi.Request) bool {
-		if r.RoutingKey() == request.TextMessage || r.RoutingKey() == request.BinaryMessage {
-			return true
-		}
-
-		return false
-	}
-
 	dispatcher := dispatch.NewRouterDispatcher(s, parse)
 	dispatcher.Use(middleware.NewErrorHandlingMiddleware())
 	dispatcher.Use(middleware.NewMetricsMiddleware("bff-deriv", skipMetrics))
@@ -156,4 +148,15 @@ func populateDefaults(cfg *Config) {
 	if cfg.MaxRequestsPerConn == 0 {
 		cfg.MaxRequestsPerConn = maxRequestsPerConnDefault
 	}
+}
+
+// skipMetrics determines whether metrics should be skipped for a given request.
+// It takes a single parameter r of type wasabi.Request.
+// It returns a boolean value: true if the request's routing key is either TextMessage or BinaryMessage, otherwise false.
+func skipMetrics(r wasabi.Request) bool {
+	if r.RoutingKey() == request.TextMessage || r.RoutingKey() == request.BinaryMessage {
+		return true
+	}
+
+	return false
 }

--- a/pkg/api/svc_test.go
+++ b/pkg/api/svc_test.go
@@ -243,3 +243,37 @@ func TestPopulateDefaults(t *testing.T) {
 		})
 	}
 }
+
+func TestSkipMetrics(t *testing.T) {
+	tests := []struct {
+		name       string
+		routingKey string
+		want       bool
+	}{
+		{
+			name:       "TextMessage routing key",
+			routingKey: request.TextMessage,
+			want:       true,
+		},
+		{
+			name:       "BinaryMessage routing key",
+			routingKey: request.BinaryMessage,
+			want:       true,
+		},
+		{
+			name:       "Other routing key",
+			routingKey: "other",
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRequest := mocks.NewMockRequest(t)
+			mockRequest.EXPECT().RoutingKey().Return(tt.routingKey)
+
+			got := skipMetrics(mockRequest)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Introduce a mechanism to skip metrics collection for passthrough requests, specifically for text and binary messages. Update the metrics middleware to accept a skip function, enhancing performance by avoiding unnecessary metric logging for these request types.