### PR TITLE
Add handling for unrecognized request methods

### DIFF
--- a/pkg/core/response_test.go
+++ b/pkg/core/response_test.go
@@ -32,7 +32,7 @@ func TestCreateResponseWithAPIError(t *testing.T) {
 	data, err := createResponse(req, nil, apiErr)
 	assert.Nil(t, err)
 
-	expected := []byte(`{"echo":{"req_id":1,"method":"testMethod","params":{"key":"value"}},"error":{"code":"BadRequest","message":"Bad Request"},"msg_type":"testMethod","req_id":1}`)
+	expected := []byte(`{"echo":{"req_id":1,"method":"testMethod","params":{"key":"value"}},"error":{"code":"BadRequest","message":"Bad Request"},"msg_type":"error","req_id":1}`)
 	assert.Equal(t, expected, data)
 }
 

--- a/pkg/core/svc.go
+++ b/pkg/core/svc.go
@@ -73,11 +73,11 @@ func (s *Service) ProcessRequest(clientConn wasabi.Connection, req *request.Requ
 		apiErr := NewAPIError("UnrecognisedRequest", "Unrecognised request method", nil)
 
 		data, err := createResponse(req, nil, apiErr)
-		if err != nil {
-			return err
+		if err == nil {
+			return clientConn.Send(wasabi.MsgTypeText, data)
 		}
 
-		return clientConn.Send(wasabi.MsgTypeText, data)
+		return err
 	}
 
 	resp, err := handler.Handle(

--- a/pkg/core/svc.go
+++ b/pkg/core/svc.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/ksysoev/deriv-api-bff/pkg/core/request"
 	"github.com/ksysoev/wasabi"
@@ -71,7 +70,14 @@ func (s *Service) ProcessRequest(clientConn wasabi.Connection, req *request.Requ
 	handler := s.ch.GetCall(req.Method)
 
 	if handler == nil {
-		return fmt.Errorf("unsupported method: %s", req.Method)
+		apiErr := NewAPIError("UnrecognisedRequest", "Unrecognised request method", nil)
+
+		data, err := createResponse(req, nil, apiErr)
+		if err != nil {
+			return err
+		}
+
+		return clientConn.Send(wasabi.MsgTypeText, data)
 	}
 
 	resp, err := handler.Handle(

--- a/pkg/core/svc_test.go
+++ b/pkg/core/svc_test.go
@@ -95,10 +95,10 @@ func TestService_ProcessRequest_UnsupportedMethod(t *testing.T) {
 
 	mockConnRegistry.EXPECT().GetConnection(mockConn).Return(conn)
 	mockCallsRepo.EXPECT().GetCall("unsupportedMethod").Return(nil)
+	mockConn.EXPECT().Send(wasabi.MsgTypeText, []byte(`{"echo":null,"error":{"code":"UnrecognisedRequest","message":"Unrecognised request method"},"msg_type":"unsupportedMethod"}`)).Return(nil)
 
 	err := svc.ProcessRequest(mockConn, mockRequest)
-	assert.NotNil(t, err)
-	assert.Equal(t, "unsupported method: unsupportedMethod", err.Error())
+	assert.Nil(t, err)
 }
 
 func TestService_ProcessRequest_HandlerError(t *testing.T) {

--- a/pkg/core/svc_test.go
+++ b/pkg/core/svc_test.go
@@ -95,7 +95,7 @@ func TestService_ProcessRequest_UnsupportedMethod(t *testing.T) {
 
 	mockConnRegistry.EXPECT().GetConnection(mockConn).Return(conn)
 	mockCallsRepo.EXPECT().GetCall("unsupportedMethod").Return(nil)
-	mockConn.EXPECT().Send(wasabi.MsgTypeText, []byte(`{"echo":null,"error":{"code":"UnrecognisedRequest","message":"Unrecognised request method"},"msg_type":"unsupportedMethod"}`)).Return(nil)
+	mockConn.EXPECT().Send(wasabi.MsgTypeText, []byte(`{"echo":null,"error":{"code":"UnrecognisedRequest","message":"Unrecognised request method"},"msg_type":"error"}`)).Return(nil)
 
 	err := svc.ProcessRequest(mockConn, mockRequest)
 	assert.Nil(t, err)
@@ -142,7 +142,7 @@ func TestService_ProcessRequest_APIError(t *testing.T) {
 	mockConn := mocks.NewMockConnection(t)
 	mockRequest := request.NewRequest(context.Background(), request.TextMessage, []byte(`{"method":"testMethod","params":{"key":"value"}}`))
 
-	expectedResp := []byte(`{"echo":{"method":"testMethod","params":{"key":"value"}},"error":{"code":"BadRequest","message":"Bad Request"},"msg_type":"testMethod"}`)
+	expectedResp := []byte(`{"echo":{"method":"testMethod","params":{"key":"value"}},"error":{"code":"BadRequest","message":"Bad Request"},"msg_type":"error"}`)
 
 	conn := NewConnection(mockConn, func(_ string) {})
 


### PR DESCRIPTION
Introduce a new error handling mechanism for unsupported request methods, returning a structured error response instead of a simple error message. Update tests to reflect the new behavior.