### PR TITLE
Add support for custom HTTP request headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,12 @@ To define an HTTP API request, use the following parameters:
 - `name`: (Optional) Name for the API call. If you want to depend on this API call and use its data in other API calls, you need to provide a name.
 - `method`: HTTP method for the request.
 - `url_template`: Template for the URL.
+- `headers`: Templates for HTTP headers.
 - `request_template`: Template for the body of the HTTP request.
 - `allow`: Fields that will be copied to the final response. If the response is an object, the fields will be copied directly. If the response is an array, the BFF will create an object with `list` as the key and the response as the value. If the response is a scalar value, the key `value` will be used.
 - `fields_map`: Allows renaming fields in the final response.
 - `depends_on`: Defines dependencies on other API calls. If dependencies are defined, their response data can be used in the request template.
+
 
 ### Template Placeholders
 
@@ -210,8 +212,12 @@ The following data is provided to each template:
   params:
     country: 
       type: "string"
+    token:
+      type: "string"
   backend:
     - method: "GET"
+      headers:
+        Authorization: "Bearer ${params.token}"
       url_template: 'http://nginx/country/${params.country}.json'
       allow: 
         - region

--- a/pkg/core/processor/factory.go
+++ b/pkg/core/processor/factory.go
@@ -14,11 +14,12 @@ type Processor interface {
 }
 
 type Config struct {
+	Tmplt       map[string]any    `json:"request_template,omitempty" yaml:"request_template,omitempty"`
+	FieldMap    map[string]string `json:"fields_map,omitempty" yaml:"fields_map,omitempty"`
+	Headers     map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
 	Name        string            `json:"name,omitempty" yaml:"name,omitempty"`
 	Method      string            `json:"method,omitempty" yaml:"method,omitempty"`
 	URLTemplate string            `json:"url_template,omitempty" yaml:"url_template,omitempty"`
-	Tmplt       map[string]any    `json:"request_template,omitempty" yaml:"request_template,omitempty"`
-	FieldMap    map[string]string `json:"fields_map,omitempty" yaml:"fields_map,omitempty"`
 	DependsOn   []string          `json:"depends_on,omitempty" yaml:"depends_on,omitempty"`
 	Allow       []string          `json:"allow,omitempty" yaml:"allow,omitempty"`
 }

--- a/pkg/core/processor/httpproc.go
+++ b/pkg/core/processor/httpproc.go
@@ -95,12 +95,14 @@ func (p *HTTPProc) Render(ctx context.Context, reqID string, param, deps map[str
 
 	req := request.NewHTTPReq(ctx, p.method, url, body, reqID)
 
-	if p.headers == nil {
+	if p.headers != nil {
 		for key, value := range p.headers {
 			headerValue, err := value.Execute(data)
 			if err != nil {
 				return nil, fmt.Errorf("fail to execute header template %s: %w", key, err)
 			}
+
+			fmt.Println("headerValue", headerValue)
 
 			req.AddHeader(key, headerValue)
 		}

--- a/pkg/core/processor/httpproc_test.go
+++ b/pkg/core/processor/httpproc_test.go
@@ -167,6 +167,32 @@ func TestNewHTTP(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "With headers success",
+			cfg: &Config{
+				Name:        "TestProcessor",
+				Method:      "GET",
+				URLTemplate: "/test/url",
+				Tmplt:       map[string]any{"key": "value"},
+				FieldMap:    map[string]string{"key1": "mappedKey1"},
+				Allow:       []string{"key1", "key2"},
+				Headers:     map[string]string{"Authorization": "Bearer ${params.token}"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "With headers parse error",
+			cfg: &Config{
+				Name:        "TestProcessor",
+				Method:      "GET",
+				URLTemplate: "/test/url",
+				Tmplt:       map[string]any{"key": "value"},
+				FieldMap:    map[string]string{"key1": "mappedKey1"},
+				Allow:       []string{"key1", "key2"},
+				Headers:     map[string]string{"Authorization": "Bearer ${params.invalid_field"},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/core/processor/httpproc_test.go
+++ b/pkg/core/processor/httpproc_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/ksysoev/deriv-api-bff/pkg/core/request"
 	"github.com/ksysoev/deriv-api-bff/pkg/core/tmpl"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHTTPProc_Parse(t *testing.T) {
@@ -189,14 +191,15 @@ func TestNewHTTP(t *testing.T) {
 
 func TestHTTPProc_Render(t *testing.T) {
 	tests := []struct {
-		proc          *HTTPProc
-		param         map[string]any
-		deps          map[string]any
-		name          string
-		wantRoutinKey string
-		reqID         string
-		wantBody      []byte
-		wantErr       bool
+		proc        *HTTPProc
+		param       map[string]any
+		deps        map[string]any
+		wantHeaders map[string]string
+		name        string
+		reqID       string
+		wantURL     string
+		wantBody    []byte
+		wantErr     bool
 	}{
 		{
 			name: "Valid URL and body template",
@@ -205,13 +208,15 @@ func TestHTTPProc_Render(t *testing.T) {
 				method:      "POST",
 				urlTemplate: tmpl.MustNewURLTmpl("http://example.com/${req_id}"),
 				tmpl:        tmpl.MustNewTmpl(`{"param": "${params.param}"}`),
+				headers:     map[string]*tmpl.StrTmpl{"Authorization": tmpl.MustNewStrTmpl("application/json")},
 			},
-			reqID:         "123",
-			param:         map[string]any{"param": "value"},
-			deps:          map[string]any{},
-			wantRoutinKey: "POST http://example.com/123",
-			wantBody:      []byte(`{"param": "value"}`),
-			wantErr:       false,
+			reqID:       "123",
+			param:       map[string]any{"param": "value"},
+			deps:        map[string]any{},
+			wantURL:     "POST http://example.com/123",
+			wantBody:    []byte(`{"param": "value"}`),
+			wantHeaders: map[string]string{"Authorization": "application/json"},
+			wantErr:     false,
 		},
 		{
 			name: "Valid URL template, no body template",
@@ -220,13 +225,15 @@ func TestHTTPProc_Render(t *testing.T) {
 				method:      "GET",
 				urlTemplate: tmpl.MustNewURLTmpl("http://example.com/${req_id}"),
 				tmpl:        nil,
+				headers:     map[string]*tmpl.StrTmpl{"Authorization": tmpl.MustNewStrTmpl("application/json")},
 			},
-			reqID:         "123",
-			param:         map[string]any{"param": "value"},
-			deps:          map[string]any{},
-			wantRoutinKey: "GET http://example.com/123",
-			wantBody:      nil,
-			wantErr:       false,
+			reqID:       "123",
+			param:       map[string]any{"param": "value"},
+			deps:        map[string]any{},
+			wantURL:     "GET http://example.com/123",
+			wantBody:    nil,
+			wantHeaders: map[string]string{"Authorization": "application/json"},
+			wantErr:     false,
 		},
 		{
 			name: "Invalid URL template",
@@ -236,12 +243,13 @@ func TestHTTPProc_Render(t *testing.T) {
 				urlTemplate: tmpl.MustNewURLTmpl("http://example.com/${params.invalid_field}"),
 				tmpl:        nil,
 			},
-			reqID:         "123",
-			param:         map[string]any{"param": "value"},
-			deps:          map[string]any{},
-			wantRoutinKey: "",
-			wantBody:      nil,
-			wantErr:       true,
+			reqID:       "123",
+			param:       map[string]any{"param": "value"},
+			deps:        map[string]any{},
+			wantURL:     "",
+			wantBody:    nil,
+			wantHeaders: nil,
+			wantErr:     true,
 		},
 		{
 			name: "Invalid body template",
@@ -251,12 +259,30 @@ func TestHTTPProc_Render(t *testing.T) {
 				urlTemplate: tmpl.MustNewURLTmpl("http://example.com/${req_id}"),
 				tmpl:        tmpl.MustNewTmpl(`{"param": "${invalid_field}"}`),
 			},
-			reqID:         "123",
-			param:         map[string]any{"param": "value"},
-			deps:          map[string]any{},
-			wantRoutinKey: "POST http://example.com/123",
-			wantBody:      nil,
-			wantErr:       true,
+			reqID:       "123",
+			param:       map[string]any{"param": "value"},
+			deps:        map[string]any{},
+			wantURL:     "POST http://example.com/123",
+			wantBody:    nil,
+			wantHeaders: nil,
+			wantErr:     true,
+		},
+		{
+			name: "Valid URL and body template with headers",
+			proc: &HTTPProc{
+				name:        "TestProcessor",
+				method:      "POST",
+				urlTemplate: tmpl.MustNewURLTmpl("http://example.com/${req_id}"),
+				tmpl:        tmpl.MustNewTmpl(`{"param": "${params.param}"}`),
+				headers:     map[string]*tmpl.StrTmpl{"Authorization": tmpl.MustNewStrTmpl("Bearer ${params.token}")},
+			},
+			reqID:       "123",
+			param:       map[string]any{"param": "value", "token": "abc123"},
+			deps:        map[string]any{},
+			wantURL:     "POST http://example.com/123",
+			wantBody:    []byte(`{"param": "value"}`),
+			wantHeaders: map[string]string{"Authorization": "Bearer abc123"},
+			wantErr:     false,
 		},
 	}
 
@@ -268,12 +294,20 @@ func TestHTTPProc_Render(t *testing.T) {
 				assert.Error(t, err)
 				assert.Nil(t, gotReq)
 			} else {
-				assert.Equal(t, tt.wantRoutinKey, gotReq.RoutingKey())
+				assert.NoError(t, err)
 
-				if tt.wantBody == nil {
-					assert.Nil(t, gotReq.Data())
-				} else {
-					assert.Equal(t, tt.wantBody, gotReq.Data())
+				req, ok := gotReq.(*request.HTTPReq)
+
+				require.True(t, ok)
+
+				http, err := req.ToHTTPRequest()
+				assert.NoError(t, err)
+
+				assert.Equal(t, tt.wantURL, req.RoutingKey())
+				assert.Equal(t, tt.wantBody, req.Data())
+
+				for key, value := range tt.wantHeaders {
+					assert.Equal(t, value, http.Header.Get(key))
 				}
 			}
 		})

--- a/pkg/core/tmpl/string_tmpl.go
+++ b/pkg/core/tmpl/string_tmpl.go
@@ -1,0 +1,60 @@
+package tmpl
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/valyala/fasttemplate"
+	"github.com/wolfeidau/jsontemplate"
+)
+
+type StrTmpl struct {
+	tmpl *fasttemplate.Template
+}
+
+func NewStrTmpl(tmpl string) (*StrTmpl, error) {
+	t, err := fasttemplate.NewTemplate(tmpl, "${", "}")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse request template: %w", err)
+	}
+
+	return &StrTmpl{tmpl: t}, nil
+}
+
+func MustNewStringTmpl(tmplRaw string) *StrTmpl {
+	tmpl, err := NewStrTmpl(tmplRaw)
+	if err != nil {
+		panic(err)
+	}
+
+	return tmpl
+}
+
+func (t *StrTmpl) Execute(params any) (string, error) {
+	jData, err := json.Marshal(params)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal request template: %w", err)
+	}
+
+	doc := jsontemplate.NewDocument(jData)
+
+	str, err := t.tmpl.ExecuteFuncStringWithErr(func(w io.Writer, path string) (int, error) {
+		v, err := doc.Read(path + ";escape")
+		if err != nil {
+			return 0, err
+		}
+
+		if str, ok := v.(string); ok {
+			return w.Write([]byte(str))
+		}
+
+		return 0, fmt.Errorf("expected string, got %T", v)
+	})
+
+	if err != nil {
+		return "", fmt.Errorf("failed to execute template: %w", err)
+	}
+
+	return str, nil
+}

--- a/pkg/core/tmpl/string_tmpl.go
+++ b/pkg/core/tmpl/string_tmpl.go
@@ -26,11 +26,11 @@ func NewStrTmpl(tmpl string) (*StrTmpl, error) {
 	return &StrTmpl{tmpl: t}, nil
 }
 
-// MustNewStringTmpl creates a new StrTmpl from the provided raw template string.
+// MustNewStrTmpl creates a new StrTmpl from the provided raw template string.
 // It takes tmplRaw of type string.
 // It returns a pointer to StrTmpl.
 // It panics if there is an error during the creation of the StrTmpl.
-func MustNewStringTmpl(tmplRaw string) *StrTmpl {
+func MustNewStrTmpl(tmplRaw string) *StrTmpl {
 	tmpl, err := NewStrTmpl(tmplRaw)
 	if err != nil {
 		panic(err)

--- a/pkg/core/tmpl/string_tmpl.go
+++ b/pkg/core/tmpl/string_tmpl.go
@@ -13,6 +13,10 @@ type StrTmpl struct {
 	tmpl *fasttemplate.Template
 }
 
+// NewStrTmpl creates a new StrTmpl instance by parsing the provided template string.
+// It takes tmpl of type string, which is the template to be parsed.
+// It returns a pointer to StrTmpl and an error.
+// It returns an error if the template parsing fails.
 func NewStrTmpl(tmpl string) (*StrTmpl, error) {
 	t, err := fasttemplate.NewTemplate(tmpl, "${", "}")
 	if err != nil {
@@ -22,6 +26,10 @@ func NewStrTmpl(tmpl string) (*StrTmpl, error) {
 	return &StrTmpl{tmpl: t}, nil
 }
 
+// MustNewStringTmpl creates a new StrTmpl from the provided raw template string.
+// It takes tmplRaw of type string.
+// It returns a pointer to StrTmpl.
+// It panics if there is an error during the creation of the StrTmpl.
 func MustNewStringTmpl(tmplRaw string) *StrTmpl {
 	tmpl, err := NewStrTmpl(tmplRaw)
 	if err != nil {
@@ -31,6 +39,11 @@ func MustNewStringTmpl(tmplRaw string) *StrTmpl {
 	return tmpl
 }
 
+// Execute processes the given parameters using a JSON template and returns the resulting string.
+// It takes params of type any, which represents the data to be used in the template.
+// It returns a string containing the processed template and an error if the operation fails.
+// It returns an error if the parameters cannot be marshaled into JSON, if the template execution fails,
+// or if the template path does not resolve to a string.
 func (t *StrTmpl) Execute(params any) (string, error) {
 	jData, err := json.Marshal(params)
 	if err != nil {

--- a/pkg/core/tmpl/string_tmpl_test.go
+++ b/pkg/core/tmpl/string_tmpl_test.go
@@ -1,0 +1,129 @@
+package tmpl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewStrTmpl(t *testing.T) {
+	tests := []struct {
+		name        string
+		tmpl        string
+		expectError bool
+	}{
+		{
+			name:        "Valid template",
+			tmpl:        "Hello, ${name}!",
+			expectError: false,
+		},
+		{
+			name:        "Invalid template",
+			tmpl:        "Hello, ${name!",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpl, err := NewStrTmpl(tt.tmpl)
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, tmpl)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, tmpl)
+			}
+		})
+	}
+}
+
+func TestMustNewStringTmpl(t *testing.T) {
+	tests := []struct {
+		name        string
+		tmpl        string
+		shouldPanic bool
+	}{
+		{
+			name:        "Valid template",
+			tmpl:        "Hello, ${name}!",
+			shouldPanic: false,
+		},
+		{
+			name:        "Invalid template",
+			tmpl:        "Hello, ${name!",
+			shouldPanic: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.shouldPanic {
+				assert.Panics(t, func() {
+					MustNewStringTmpl(tt.tmpl)
+				})
+			} else {
+				assert.NotPanics(t, func() {
+					tmpl := MustNewStringTmpl(tt.tmpl)
+					assert.NotNil(t, tmpl)
+				})
+			}
+		})
+	}
+}
+
+func TestStrTmpl_Execute(t *testing.T) {
+	tests := []struct {
+		name        string
+		tmpl        string
+		params      any
+		expected    string
+		expectError bool
+	}{
+		{
+			name:        "Valid template with valid params",
+			tmpl:        "Hello, ${name}!",
+			params:      map[string]string{"name": "World"},
+			expected:    "Hello, World!",
+			expectError: false,
+		},
+		{
+			name:        "Valid template with missing params",
+			tmpl:        "Hello, ${name}!",
+			params:      map[string]string{},
+			expected:    "Hello, !",
+			expectError: true,
+		},
+		{
+			name:        "Valid template with integer params",
+			tmpl:        "Hello, ${name}!",
+			params:      map[string]int{"name": 123},
+			expected:    "Hello, 123!",
+			expectError: false,
+		},
+		{
+			name:        "Invalid JSON params",
+			tmpl:        "Hello, ${name}!",
+			params:      func() {},
+			expected:    "",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpl, err := NewStrTmpl(tt.tmpl)
+			assert.NoError(t, err)
+			assert.NotNil(t, tmpl)
+
+			result, err := tmpl.Execute(tt.params)
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Empty(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/core/tmpl/string_tmpl_test.go
+++ b/pkg/core/tmpl/string_tmpl_test.go
@@ -60,11 +60,11 @@ func TestMustNewStringTmpl(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.shouldPanic {
 				assert.Panics(t, func() {
-					MustNewStringTmpl(tt.tmpl)
+					MustNewStrTmpl(tt.tmpl)
 				})
 			} else {
 				assert.NotPanics(t, func() {
-					tmpl := MustNewStringTmpl(tt.tmpl)
+					tmpl := MustNewStrTmpl(tt.tmpl)
 					assert.NotNil(t, tmpl)
 				})
 			}


### PR DESCRIPTION
Introduce the ability to define custom headers for HTTP requests in the configuration, enhancing flexibility in request handling.