### PR TITLE
Replace map[string]any with []byte for params handling

### DIFF
--- a/pkg/core/handler/handler.go
+++ b/pkg/core/handler/handler.go
@@ -11,12 +11,12 @@ import (
 type Parser func([]byte) (map[string]any, map[string]any, error)
 
 type Validator interface {
-	Validate(data map[string]any) error
+	Validate(data []byte) error
 }
 
 type RenderParser interface {
 	Name() string
-	Render(ctx context.Context, reqID string, params map[string]any, deps map[string]any) (core.Request, error)
+	Render(ctx context.Context, reqID string, params []byte, deps map[string]any) (core.Request, error)
 	Parse(data []byte) (map[string]any, map[string]any, error)
 }
 
@@ -46,7 +46,7 @@ func New(val Validator, proc []RenderParser, composeFactory func(core.Waiter) Wa
 // It takes a context.Context, a map of parameters, a core.Waiter, and a core.Sender.
 // It returns a map containing the composed results and an error if any occurs during validation or sending requests.
 // It returns an error if the validation of parameters fails or if sending a request fails.
-func (h *Handler) Handle(ctx context.Context, params map[string]any, waiter core.Waiter, send core.Sender) (map[string]any, error) {
+func (h *Handler) Handle(ctx context.Context, params []byte, waiter core.Waiter, send core.Sender) (map[string]any, error) {
 	if err := h.validator.Validate(params); err != nil {
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func (h *Handler) Handle(ctx context.Context, params map[string]any, waiter core
 // It takes a context `ctx` for managing request lifecycle, a map `params` containing parameters for the requests, and a `comp` of type WaitComposer for preparing the requests.
 // It returns an iterator function that yields requests of type `request`.
 // The function handles context cancellation and prepares requests using the provided processors. It panics if template execution fails during request rendering.
-func (h *Handler) requests(ctx context.Context, params map[string]any, comp WaitComposer) iter.Seq[core.Request] {
+func (h *Handler) requests(ctx context.Context, params []byte, comp WaitComposer) iter.Seq[core.Request] {
 	return func(yield func(core.Request) bool) {
 		for _, proc := range h.processors {
 			if ctx.Err() != nil {

--- a/pkg/core/handler/handler.go
+++ b/pkg/core/handler/handler.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"iter"
 
@@ -46,7 +47,7 @@ func New(val Validator, proc []RenderParser, composeFactory func(core.Waiter) Wa
 // It takes a context.Context, a map of parameters, a core.Waiter, and a core.Sender.
 // It returns a map containing the composed results and an error if any occurs during validation or sending requests.
 // It returns an error if the validation of parameters fails or if sending a request fails.
-func (h *Handler) Handle(ctx context.Context, params []byte, waiter core.Waiter, send core.Sender) (map[string]any, error) {
+func (h *Handler) Handle(ctx context.Context, params json.RawMessage, waiter core.Waiter, send core.Sender) (map[string]any, error) {
 	if err := h.validator.Validate(params); err != nil {
 		return nil, err
 	}
@@ -69,7 +70,7 @@ func (h *Handler) Handle(ctx context.Context, params []byte, waiter core.Waiter,
 // It takes a context `ctx` for managing request lifecycle, a map `params` containing parameters for the requests, and a `comp` of type WaitComposer for preparing the requests.
 // It returns an iterator function that yields requests of type `request`.
 // The function handles context cancellation and prepares requests using the provided processors. It panics if template execution fails during request rendering.
-func (h *Handler) requests(ctx context.Context, params []byte, comp WaitComposer) iter.Seq[core.Request] {
+func (h *Handler) requests(ctx context.Context, params json.RawMessage, comp WaitComposer) iter.Seq[core.Request] {
 	return func(yield func(core.Request) bool) {
 		for _, proc := range h.processors {
 			if ctx.Err() != nil {

--- a/pkg/core/handler/handler_test.go
+++ b/pkg/core/handler/handler_test.go
@@ -65,134 +65,134 @@ func TestHandle_Success(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{"key": "value"}, resp)
 }
 
-// func TestHandle_ValidationError(t *testing.T) {
-// 	expectedParams := map[string]any{"key": "value"}
+func TestHandle_ValidationError(t *testing.T) {
+	expectedParams := []byte(`{"key": "value"}`)
 
-// 	validator := NewMockValidator(t)
-// 	validator.EXPECT().Validate(expectedParams).Return(assert.AnError)
+	validator := NewMockValidator(t)
+	validator.EXPECT().Validate(expectedParams).Return(assert.AnError)
 
-// 	renderParser := NewMockRenderParser(t)
-// 	waitComposer := NewMockWaitComposer(t)
+	renderParser := NewMockRenderParser(t)
+	waitComposer := NewMockWaitComposer(t)
 
-// 	handler := New(validator, []RenderParser{renderParser}, func(core.Waiter) WaitComposer {
-// 		return waitComposer
-// 	})
+	handler := New(validator, []RenderParser{renderParser}, func(core.Waiter) WaitComposer {
+		return waitComposer
+	})
 
-// 	ctx := context.Background()
+	ctx := context.Background()
 
-// 	echoChan := make(chan []byte, 1)
-// 	waiter := func() (string, <-chan []byte) {
-// 		return "1", echoChan
-// 	}
+	echoChan := make(chan []byte, 1)
+	waiter := func() (string, <-chan []byte) {
+		return "1", echoChan
+	}
 
-// 	sender := func(req core.Request) error {
-// 		echoChan <- req.Data()
-// 		return nil
-// 	}
+	sender := func(req core.Request) error {
+		echoChan <- req.Data()
+		return nil
+	}
 
-// 	resp, err := handler.Handle(ctx, expectedParams, waiter, sender)
-// 	assert.ErrorIs(t, err, assert.AnError)
-// 	assert.Nil(t, resp)
-// }
+	resp, err := handler.Handle(ctx, expectedParams, waiter, sender)
+	assert.ErrorIs(t, err, assert.AnError)
+	assert.Nil(t, resp)
+}
 
-// func TestHandle_SendError(t *testing.T) {
-// 	expectedParams := map[string]any{"key": "value"}
-// 	expectedCallName := "test"
+func TestHandle_SendError(t *testing.T) {
+	expectedParams := []byte(`{"key": "value"}`)
+	expectedCallName := "test"
 
-// 	validator := NewMockValidator(t)
-// 	validator.EXPECT().Validate(expectedParams).Return(nil)
+	validator := NewMockValidator(t)
+	validator.EXPECT().Validate(expectedParams).Return(nil)
 
-// 	mockReq := core.NewMockRequest(t)
+	mockReq := core.NewMockRequest(t)
 
-// 	renderParser := NewMockRenderParser(t)
-// 	renderParser.EXPECT().Render(mock.Anything, mock.Anything, expectedParams, make(map[string]any)).Return(mockReq, nil)
-// 	renderParser.EXPECT().Name().Return(expectedCallName)
+	renderParser := NewMockRenderParser(t)
+	renderParser.EXPECT().Render(mock.Anything, mock.Anything, expectedParams, make(map[string]any)).Return(mockReq, nil)
+	renderParser.EXPECT().Name().Return(expectedCallName)
 
-// 	waitComposer := NewMockWaitComposer(t)
-// 	waitComposer.EXPECT().Prepare(mock.Anything, expectedCallName, mock.Anything).Return("1", make(map[string]any), nil)
+	waitComposer := NewMockWaitComposer(t)
+	waitComposer.EXPECT().Prepare(mock.Anything, expectedCallName, mock.Anything).Return("1", make(map[string]any), nil)
 
-// 	handler := New(validator, []RenderParser{renderParser, renderParser}, func(core.Waiter) WaitComposer {
-// 		return waitComposer
-// 	})
+	handler := New(validator, []RenderParser{renderParser, renderParser}, func(core.Waiter) WaitComposer {
+		return waitComposer
+	})
 
-// 	ctx := context.Background()
+	ctx := context.Background()
 
-// 	echoChan := make(chan []byte, 1)
-// 	waiter := func() (string, <-chan []byte) {
-// 		return "1", echoChan
-// 	}
+	echoChan := make(chan []byte, 1)
+	waiter := func() (string, <-chan []byte) {
+		return "1", echoChan
+	}
 
-// 	sender := func(_ core.Request) error {
-// 		return assert.AnError
-// 	}
+	sender := func(_ core.Request) error {
+		return assert.AnError
+	}
 
-// 	resp, err := handler.Handle(ctx, expectedParams, waiter, sender)
-// 	assert.ErrorIs(t, err, assert.AnError)
-// 	assert.Nil(t, resp)
-// }
+	resp, err := handler.Handle(ctx, expectedParams, waiter, sender)
+	assert.ErrorIs(t, err, assert.AnError)
+	assert.Nil(t, resp)
+}
 
-// func TestHandle_CancelledContext(t *testing.T) {
-// 	expectedParams := map[string]any{"key": "value"}
+func TestHandle_CancelledContext(t *testing.T) {
+	expectedParams := []byte(`{"key": "value"}`)
 
-// 	validator := NewMockValidator(t)
-// 	validator.EXPECT().Validate(expectedParams).Return(nil)
+	validator := NewMockValidator(t)
+	validator.EXPECT().Validate(expectedParams).Return(nil)
 
-// 	renderParser := NewMockRenderParser(t)
+	renderParser := NewMockRenderParser(t)
 
-// 	ctx, cancel := context.WithCancel(context.Background())
-// 	cancel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
 
-// 	waitComposer := NewMockWaitComposer(t)
-// 	waitComposer.EXPECT().Compose().Return(nil, ctx.Err())
+	waitComposer := NewMockWaitComposer(t)
+	waitComposer.EXPECT().Compose().Return(nil, ctx.Err())
 
-// 	handler := New(validator, []RenderParser{renderParser}, func(core.Waiter) WaitComposer {
-// 		return waitComposer
-// 	})
+	handler := New(validator, []RenderParser{renderParser}, func(core.Waiter) WaitComposer {
+		return waitComposer
+	})
 
-// 	echoChan := make(chan []byte, 1)
-// 	waiter := func() (string, <-chan []byte) {
-// 		return "1", echoChan
-// 	}
+	echoChan := make(chan []byte, 1)
+	waiter := func() (string, <-chan []byte) {
+		return "1", echoChan
+	}
 
-// 	sender := func(_ core.Request) error {
-// 		return nil
-// 	}
+	sender := func(_ core.Request) error {
+		return nil
+	}
 
-// 	resp, err := handler.Handle(ctx, expectedParams, waiter, sender)
-// 	assert.ErrorIs(t, err, ctx.Err())
-// 	assert.Nil(t, resp)
-// }
+	resp, err := handler.Handle(ctx, expectedParams, waiter, sender)
+	assert.ErrorIs(t, err, ctx.Err())
+	assert.Nil(t, resp)
+}
 
-// func TestHandle_PrepareError(t *testing.T) {
-// 	expectedParams := map[string]any{"key": "value"}
-// 	expectedCallName := "test"
+func TestHandle_PrepareError(t *testing.T) {
+	expectedParams := []byte(`{"key": "value"}`)
+	expectedCallName := "test"
 
-// 	validator := NewMockValidator(t)
-// 	validator.EXPECT().Validate(expectedParams).Return(nil)
+	validator := NewMockValidator(t)
+	validator.EXPECT().Validate(expectedParams).Return(nil)
 
-// 	renderParser := NewMockRenderParser(t)
-// 	renderParser.EXPECT().Name().Return(expectedCallName)
+	renderParser := NewMockRenderParser(t)
+	renderParser.EXPECT().Name().Return(expectedCallName)
 
-// 	waitComposer := NewMockWaitComposer(t)
-// 	waitComposer.EXPECT().Prepare(mock.Anything, expectedCallName, mock.Anything).Return("", nil, assert.AnError)
-// 	waitComposer.EXPECT().Compose().Return(nil, assert.AnError)
+	waitComposer := NewMockWaitComposer(t)
+	waitComposer.EXPECT().Prepare(mock.Anything, expectedCallName, mock.Anything).Return("", nil, assert.AnError)
+	waitComposer.EXPECT().Compose().Return(nil, assert.AnError)
 
-// 	handler := New(validator, []RenderParser{renderParser}, func(core.Waiter) WaitComposer {
-// 		return waitComposer
-// 	})
+	handler := New(validator, []RenderParser{renderParser}, func(core.Waiter) WaitComposer {
+		return waitComposer
+	})
 
-// 	ctx := context.Background()
+	ctx := context.Background()
 
-// 	echoChan := make(chan []byte, 1)
-// 	waiter := func() (string, <-chan []byte) {
-// 		return "1", echoChan
-// 	}
+	echoChan := make(chan []byte, 1)
+	waiter := func() (string, <-chan []byte) {
+		return "1", echoChan
+	}
 
-// 	sender := func(_ core.Request) error {
-// 		return nil
-// 	}
+	sender := func(_ core.Request) error {
+		return nil
+	}
 
-// 	resp, err := handler.Handle(ctx, expectedParams, waiter, sender)
-// 	assert.ErrorIs(t, err, assert.AnError)
-// 	assert.Nil(t, resp)
-// }
+	resp, err := handler.Handle(ctx, expectedParams, waiter, sender)
+	assert.ErrorIs(t, err, assert.AnError)
+	assert.Nil(t, resp)
+}

--- a/pkg/core/handler/handler_test.go
+++ b/pkg/core/handler/handler_test.go
@@ -25,21 +25,23 @@ func TestNew(t *testing.T) {
 }
 
 func TestHandle_Success(t *testing.T) {
-	expectedParams := map[string]any{"key": "value"}
+	params := []byte(`{"key": "value"}`)
+
+	expectedResult := map[string]any{"key": "value"}
 	expectedCallName := "test"
 
 	mockReq := core.NewMockRequest(t)
 	mockReq.EXPECT().Data().Return([]byte("data"))
 
 	validator := NewMockValidator(t)
-	validator.EXPECT().Validate(expectedParams).Return(nil)
+	validator.EXPECT().Validate(params).Return(nil)
 
 	renderParser := NewMockRenderParser(t)
 	renderParser.EXPECT().Name().Return(expectedCallName)
-	renderParser.EXPECT().Render(mock.Anything, mock.Anything, expectedParams, make(map[string]any)).Return(mockReq, nil)
+	renderParser.EXPECT().Render(mock.Anything, mock.Anything, params, make(map[string]any)).Return(mockReq, nil)
 
 	waitComposer := NewMockWaitComposer(t)
-	waitComposer.EXPECT().Compose().Return(expectedParams, nil)
+	waitComposer.EXPECT().Compose().Return(expectedResult, nil)
 	waitComposer.EXPECT().Prepare(mock.Anything, expectedCallName, mock.Anything).Return("1", make(map[string]any), nil)
 
 	handler := New(validator, []RenderParser{renderParser}, func(core.Waiter) WaitComposer {
@@ -58,139 +60,139 @@ func TestHandle_Success(t *testing.T) {
 		return nil
 	}
 
-	resp, err := handler.Handle(ctx, expectedParams, waiter, sender)
+	resp, err := handler.Handle(ctx, params, waiter, sender)
 	assert.Nil(t, err)
 	assert.Equal(t, map[string]interface{}{"key": "value"}, resp)
 }
 
-func TestHandle_ValidationError(t *testing.T) {
-	expectedParams := map[string]any{"key": "value"}
+// func TestHandle_ValidationError(t *testing.T) {
+// 	expectedParams := map[string]any{"key": "value"}
 
-	validator := NewMockValidator(t)
-	validator.EXPECT().Validate(expectedParams).Return(assert.AnError)
+// 	validator := NewMockValidator(t)
+// 	validator.EXPECT().Validate(expectedParams).Return(assert.AnError)
 
-	renderParser := NewMockRenderParser(t)
-	waitComposer := NewMockWaitComposer(t)
+// 	renderParser := NewMockRenderParser(t)
+// 	waitComposer := NewMockWaitComposer(t)
 
-	handler := New(validator, []RenderParser{renderParser}, func(core.Waiter) WaitComposer {
-		return waitComposer
-	})
+// 	handler := New(validator, []RenderParser{renderParser}, func(core.Waiter) WaitComposer {
+// 		return waitComposer
+// 	})
 
-	ctx := context.Background()
+// 	ctx := context.Background()
 
-	echoChan := make(chan []byte, 1)
-	waiter := func() (string, <-chan []byte) {
-		return "1", echoChan
-	}
+// 	echoChan := make(chan []byte, 1)
+// 	waiter := func() (string, <-chan []byte) {
+// 		return "1", echoChan
+// 	}
 
-	sender := func(req core.Request) error {
-		echoChan <- req.Data()
-		return nil
-	}
+// 	sender := func(req core.Request) error {
+// 		echoChan <- req.Data()
+// 		return nil
+// 	}
 
-	resp, err := handler.Handle(ctx, expectedParams, waiter, sender)
-	assert.ErrorIs(t, err, assert.AnError)
-	assert.Nil(t, resp)
-}
+// 	resp, err := handler.Handle(ctx, expectedParams, waiter, sender)
+// 	assert.ErrorIs(t, err, assert.AnError)
+// 	assert.Nil(t, resp)
+// }
 
-func TestHandle_SendError(t *testing.T) {
-	expectedParams := map[string]any{"key": "value"}
-	expectedCallName := "test"
+// func TestHandle_SendError(t *testing.T) {
+// 	expectedParams := map[string]any{"key": "value"}
+// 	expectedCallName := "test"
 
-	validator := NewMockValidator(t)
-	validator.EXPECT().Validate(expectedParams).Return(nil)
+// 	validator := NewMockValidator(t)
+// 	validator.EXPECT().Validate(expectedParams).Return(nil)
 
-	mockReq := core.NewMockRequest(t)
+// 	mockReq := core.NewMockRequest(t)
 
-	renderParser := NewMockRenderParser(t)
-	renderParser.EXPECT().Render(mock.Anything, mock.Anything, expectedParams, make(map[string]any)).Return(mockReq, nil)
-	renderParser.EXPECT().Name().Return(expectedCallName)
+// 	renderParser := NewMockRenderParser(t)
+// 	renderParser.EXPECT().Render(mock.Anything, mock.Anything, expectedParams, make(map[string]any)).Return(mockReq, nil)
+// 	renderParser.EXPECT().Name().Return(expectedCallName)
 
-	waitComposer := NewMockWaitComposer(t)
-	waitComposer.EXPECT().Prepare(mock.Anything, expectedCallName, mock.Anything).Return("1", make(map[string]any), nil)
+// 	waitComposer := NewMockWaitComposer(t)
+// 	waitComposer.EXPECT().Prepare(mock.Anything, expectedCallName, mock.Anything).Return("1", make(map[string]any), nil)
 
-	handler := New(validator, []RenderParser{renderParser, renderParser}, func(core.Waiter) WaitComposer {
-		return waitComposer
-	})
+// 	handler := New(validator, []RenderParser{renderParser, renderParser}, func(core.Waiter) WaitComposer {
+// 		return waitComposer
+// 	})
 
-	ctx := context.Background()
+// 	ctx := context.Background()
 
-	echoChan := make(chan []byte, 1)
-	waiter := func() (string, <-chan []byte) {
-		return "1", echoChan
-	}
+// 	echoChan := make(chan []byte, 1)
+// 	waiter := func() (string, <-chan []byte) {
+// 		return "1", echoChan
+// 	}
 
-	sender := func(_ core.Request) error {
-		return assert.AnError
-	}
+// 	sender := func(_ core.Request) error {
+// 		return assert.AnError
+// 	}
 
-	resp, err := handler.Handle(ctx, expectedParams, waiter, sender)
-	assert.ErrorIs(t, err, assert.AnError)
-	assert.Nil(t, resp)
-}
+// 	resp, err := handler.Handle(ctx, expectedParams, waiter, sender)
+// 	assert.ErrorIs(t, err, assert.AnError)
+// 	assert.Nil(t, resp)
+// }
 
-func TestHandle_CancelledContext(t *testing.T) {
-	expectedParams := map[string]any{"key": "value"}
+// func TestHandle_CancelledContext(t *testing.T) {
+// 	expectedParams := map[string]any{"key": "value"}
 
-	validator := NewMockValidator(t)
-	validator.EXPECT().Validate(expectedParams).Return(nil)
+// 	validator := NewMockValidator(t)
+// 	validator.EXPECT().Validate(expectedParams).Return(nil)
 
-	renderParser := NewMockRenderParser(t)
+// 	renderParser := NewMockRenderParser(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+// 	ctx, cancel := context.WithCancel(context.Background())
+// 	cancel()
 
-	waitComposer := NewMockWaitComposer(t)
-	waitComposer.EXPECT().Compose().Return(nil, ctx.Err())
+// 	waitComposer := NewMockWaitComposer(t)
+// 	waitComposer.EXPECT().Compose().Return(nil, ctx.Err())
 
-	handler := New(validator, []RenderParser{renderParser}, func(core.Waiter) WaitComposer {
-		return waitComposer
-	})
+// 	handler := New(validator, []RenderParser{renderParser}, func(core.Waiter) WaitComposer {
+// 		return waitComposer
+// 	})
 
-	echoChan := make(chan []byte, 1)
-	waiter := func() (string, <-chan []byte) {
-		return "1", echoChan
-	}
+// 	echoChan := make(chan []byte, 1)
+// 	waiter := func() (string, <-chan []byte) {
+// 		return "1", echoChan
+// 	}
 
-	sender := func(_ core.Request) error {
-		return nil
-	}
+// 	sender := func(_ core.Request) error {
+// 		return nil
+// 	}
 
-	resp, err := handler.Handle(ctx, expectedParams, waiter, sender)
-	assert.ErrorIs(t, err, ctx.Err())
-	assert.Nil(t, resp)
-}
+// 	resp, err := handler.Handle(ctx, expectedParams, waiter, sender)
+// 	assert.ErrorIs(t, err, ctx.Err())
+// 	assert.Nil(t, resp)
+// }
 
-func TestHandle_PrepareError(t *testing.T) {
-	expectedParams := map[string]any{"key": "value"}
-	expectedCallName := "test"
+// func TestHandle_PrepareError(t *testing.T) {
+// 	expectedParams := map[string]any{"key": "value"}
+// 	expectedCallName := "test"
 
-	validator := NewMockValidator(t)
-	validator.EXPECT().Validate(expectedParams).Return(nil)
+// 	validator := NewMockValidator(t)
+// 	validator.EXPECT().Validate(expectedParams).Return(nil)
 
-	renderParser := NewMockRenderParser(t)
-	renderParser.EXPECT().Name().Return(expectedCallName)
+// 	renderParser := NewMockRenderParser(t)
+// 	renderParser.EXPECT().Name().Return(expectedCallName)
 
-	waitComposer := NewMockWaitComposer(t)
-	waitComposer.EXPECT().Prepare(mock.Anything, expectedCallName, mock.Anything).Return("", nil, assert.AnError)
-	waitComposer.EXPECT().Compose().Return(nil, assert.AnError)
+// 	waitComposer := NewMockWaitComposer(t)
+// 	waitComposer.EXPECT().Prepare(mock.Anything, expectedCallName, mock.Anything).Return("", nil, assert.AnError)
+// 	waitComposer.EXPECT().Compose().Return(nil, assert.AnError)
 
-	handler := New(validator, []RenderParser{renderParser}, func(core.Waiter) WaitComposer {
-		return waitComposer
-	})
+// 	handler := New(validator, []RenderParser{renderParser}, func(core.Waiter) WaitComposer {
+// 		return waitComposer
+// 	})
 
-	ctx := context.Background()
+// 	ctx := context.Background()
 
-	echoChan := make(chan []byte, 1)
-	waiter := func() (string, <-chan []byte) {
-		return "1", echoChan
-	}
+// 	echoChan := make(chan []byte, 1)
+// 	waiter := func() (string, <-chan []byte) {
+// 		return "1", echoChan
+// 	}
 
-	sender := func(_ core.Request) error {
-		return nil
-	}
+// 	sender := func(_ core.Request) error {
+// 		return nil
+// 	}
 
-	resp, err := handler.Handle(ctx, expectedParams, waiter, sender)
-	assert.ErrorIs(t, err, assert.AnError)
-	assert.Nil(t, resp)
-}
+// 	resp, err := handler.Handle(ctx, expectedParams, waiter, sender)
+// 	assert.ErrorIs(t, err, assert.AnError)
+// 	assert.Nil(t, resp)
+// }

--- a/pkg/core/handler/render_parser_mock.go
+++ b/pkg/core/handler/render_parser_mock.go
@@ -137,7 +137,7 @@ func (_c *MockRenderParser_Parse_Call) RunAndReturn(run func([]byte) (map[string
 }
 
 // Render provides a mock function with given fields: ctx, reqID, params, deps
-func (_m *MockRenderParser) Render(ctx context.Context, reqID string, params map[string]any, deps map[string]any) (core.Request, error) {
+func (_m *MockRenderParser) Render(ctx context.Context, reqID string, params []byte, deps map[string]any) (core.Request, error) {
 	ret := _m.Called(ctx, reqID, params, deps)
 
 	if len(ret) == 0 {
@@ -146,10 +146,10 @@ func (_m *MockRenderParser) Render(ctx context.Context, reqID string, params map
 
 	var r0 core.Request
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, map[string]any, map[string]any) (core.Request, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, []byte, map[string]any) (core.Request, error)); ok {
 		return rf(ctx, reqID, params, deps)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, map[string]any, map[string]any) core.Request); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, []byte, map[string]any) core.Request); ok {
 		r0 = rf(ctx, reqID, params, deps)
 	} else {
 		if ret.Get(0) != nil {
@@ -157,7 +157,7 @@ func (_m *MockRenderParser) Render(ctx context.Context, reqID string, params map
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, map[string]any, map[string]any) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, string, []byte, map[string]any) error); ok {
 		r1 = rf(ctx, reqID, params, deps)
 	} else {
 		r1 = ret.Error(1)
@@ -174,15 +174,15 @@ type MockRenderParser_Render_Call struct {
 // Render is a helper method to define mock.On call
 //   - ctx context.Context
 //   - reqID string
-//   - params map[string]any
+//   - params []byte
 //   - deps map[string]any
 func (_e *MockRenderParser_Expecter) Render(ctx interface{}, reqID interface{}, params interface{}, deps interface{}) *MockRenderParser_Render_Call {
 	return &MockRenderParser_Render_Call{Call: _e.mock.On("Render", ctx, reqID, params, deps)}
 }
 
-func (_c *MockRenderParser_Render_Call) Run(run func(ctx context.Context, reqID string, params map[string]any, deps map[string]any)) *MockRenderParser_Render_Call {
+func (_c *MockRenderParser_Render_Call) Run(run func(ctx context.Context, reqID string, params []byte, deps map[string]any)) *MockRenderParser_Render_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(map[string]any), args[3].(map[string]any))
+		run(args[0].(context.Context), args[1].(string), args[2].([]byte), args[3].(map[string]any))
 	})
 	return _c
 }
@@ -192,7 +192,7 @@ func (_c *MockRenderParser_Render_Call) Return(_a0 core.Request, _a1 error) *Moc
 	return _c
 }
 
-func (_c *MockRenderParser_Render_Call) RunAndReturn(run func(context.Context, string, map[string]any, map[string]any) (core.Request, error)) *MockRenderParser_Render_Call {
+func (_c *MockRenderParser_Render_Call) RunAndReturn(run func(context.Context, string, []byte, map[string]any) (core.Request, error)) *MockRenderParser_Render_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/core/handler/validator_mock.go
+++ b/pkg/core/handler/validator_mock.go
@@ -20,7 +20,7 @@ func (_m *MockValidator) EXPECT() *MockValidator_Expecter {
 }
 
 // Validate provides a mock function with given fields: data
-func (_m *MockValidator) Validate(data map[string]any) error {
+func (_m *MockValidator) Validate(data []byte) error {
 	ret := _m.Called(data)
 
 	if len(ret) == 0 {
@@ -28,7 +28,7 @@ func (_m *MockValidator) Validate(data map[string]any) error {
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(map[string]any) error); ok {
+	if rf, ok := ret.Get(0).(func([]byte) error); ok {
 		r0 = rf(data)
 	} else {
 		r0 = ret.Error(0)
@@ -43,14 +43,14 @@ type MockValidator_Validate_Call struct {
 }
 
 // Validate is a helper method to define mock.On call
-//   - data map[string]any
+//   - data []byte
 func (_e *MockValidator_Expecter) Validate(data interface{}) *MockValidator_Validate_Call {
 	return &MockValidator_Validate_Call{Call: _e.mock.On("Validate", data)}
 }
 
-func (_c *MockValidator_Validate_Call) Run(run func(data map[string]any)) *MockValidator_Validate_Call {
+func (_c *MockValidator_Validate_Call) Run(run func(data []byte)) *MockValidator_Validate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(map[string]any))
+		run(args[0].([]byte))
 	})
 	return _c
 }
@@ -60,7 +60,7 @@ func (_c *MockValidator_Validate_Call) Return(_a0 error) *MockValidator_Validate
 	return _c
 }
 
-func (_c *MockValidator_Validate_Call) RunAndReturn(run func(map[string]any) error) *MockValidator_Validate_Call {
+func (_c *MockValidator_Validate_Call) RunAndReturn(run func([]byte) error) *MockValidator_Validate_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/core/handler_mock.go
+++ b/pkg/core/handler_mock.go
@@ -6,6 +6,7 @@ package core
 
 import (
 	context "context"
+	json "encoding/json"
 
 	mock "github.com/stretchr/testify/mock"
 )
@@ -24,7 +25,7 @@ func (_m *MockHandler) EXPECT() *MockHandler_Expecter {
 }
 
 // Handle provides a mock function with given fields: ctx, params, watcher, send
-func (_m *MockHandler) Handle(ctx context.Context, params []byte, watcher Waiter, send Sender) (map[string]any, error) {
+func (_m *MockHandler) Handle(ctx context.Context, params json.RawMessage, watcher Waiter, send Sender) (map[string]any, error) {
 	ret := _m.Called(ctx, params, watcher, send)
 
 	if len(ret) == 0 {
@@ -33,10 +34,10 @@ func (_m *MockHandler) Handle(ctx context.Context, params []byte, watcher Waiter
 
 	var r0 map[string]any
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, []byte, Waiter, Sender) (map[string]any, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, json.RawMessage, Waiter, Sender) (map[string]any, error)); ok {
 		return rf(ctx, params, watcher, send)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, []byte, Waiter, Sender) map[string]any); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, json.RawMessage, Waiter, Sender) map[string]any); ok {
 		r0 = rf(ctx, params, watcher, send)
 	} else {
 		if ret.Get(0) != nil {
@@ -44,7 +45,7 @@ func (_m *MockHandler) Handle(ctx context.Context, params []byte, watcher Waiter
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, []byte, Waiter, Sender) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, json.RawMessage, Waiter, Sender) error); ok {
 		r1 = rf(ctx, params, watcher, send)
 	} else {
 		r1 = ret.Error(1)
@@ -60,16 +61,16 @@ type MockHandler_Handle_Call struct {
 
 // Handle is a helper method to define mock.On call
 //   - ctx context.Context
-//   - params []byte
+//   - params json.RawMessage
 //   - watcher Waiter
 //   - send Sender
 func (_e *MockHandler_Expecter) Handle(ctx interface{}, params interface{}, watcher interface{}, send interface{}) *MockHandler_Handle_Call {
 	return &MockHandler_Handle_Call{Call: _e.mock.On("Handle", ctx, params, watcher, send)}
 }
 
-func (_c *MockHandler_Handle_Call) Run(run func(ctx context.Context, params []byte, watcher Waiter, send Sender)) *MockHandler_Handle_Call {
+func (_c *MockHandler_Handle_Call) Run(run func(ctx context.Context, params json.RawMessage, watcher Waiter, send Sender)) *MockHandler_Handle_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].([]byte), args[2].(Waiter), args[3].(Sender))
+		run(args[0].(context.Context), args[1].(json.RawMessage), args[2].(Waiter), args[3].(Sender))
 	})
 	return _c
 }
@@ -79,7 +80,7 @@ func (_c *MockHandler_Handle_Call) Return(_a0 map[string]any, _a1 error) *MockHa
 	return _c
 }
 
-func (_c *MockHandler_Handle_Call) RunAndReturn(run func(context.Context, []byte, Waiter, Sender) (map[string]any, error)) *MockHandler_Handle_Call {
+func (_c *MockHandler_Handle_Call) RunAndReturn(run func(context.Context, json.RawMessage, Waiter, Sender) (map[string]any, error)) *MockHandler_Handle_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/core/handler_mock.go
+++ b/pkg/core/handler_mock.go
@@ -24,7 +24,7 @@ func (_m *MockHandler) EXPECT() *MockHandler_Expecter {
 }
 
 // Handle provides a mock function with given fields: ctx, params, watcher, send
-func (_m *MockHandler) Handle(ctx context.Context, params map[string]any, watcher Waiter, send Sender) (map[string]any, error) {
+func (_m *MockHandler) Handle(ctx context.Context, params []byte, watcher Waiter, send Sender) (map[string]any, error) {
 	ret := _m.Called(ctx, params, watcher, send)
 
 	if len(ret) == 0 {
@@ -33,10 +33,10 @@ func (_m *MockHandler) Handle(ctx context.Context, params map[string]any, watche
 
 	var r0 map[string]any
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, map[string]any, Waiter, Sender) (map[string]any, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, []byte, Waiter, Sender) (map[string]any, error)); ok {
 		return rf(ctx, params, watcher, send)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, map[string]any, Waiter, Sender) map[string]any); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, []byte, Waiter, Sender) map[string]any); ok {
 		r0 = rf(ctx, params, watcher, send)
 	} else {
 		if ret.Get(0) != nil {
@@ -44,7 +44,7 @@ func (_m *MockHandler) Handle(ctx context.Context, params map[string]any, watche
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, map[string]any, Waiter, Sender) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, []byte, Waiter, Sender) error); ok {
 		r1 = rf(ctx, params, watcher, send)
 	} else {
 		r1 = ret.Error(1)
@@ -60,16 +60,16 @@ type MockHandler_Handle_Call struct {
 
 // Handle is a helper method to define mock.On call
 //   - ctx context.Context
-//   - params map[string]any
+//   - params []byte
 //   - watcher Waiter
 //   - send Sender
 func (_e *MockHandler_Expecter) Handle(ctx interface{}, params interface{}, watcher interface{}, send interface{}) *MockHandler_Handle_Call {
 	return &MockHandler_Handle_Call{Call: _e.mock.On("Handle", ctx, params, watcher, send)}
 }
 
-func (_c *MockHandler_Handle_Call) Run(run func(ctx context.Context, params map[string]any, watcher Waiter, send Sender)) *MockHandler_Handle_Call {
+func (_c *MockHandler_Handle_Call) Run(run func(ctx context.Context, params []byte, watcher Waiter, send Sender)) *MockHandler_Handle_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(map[string]any), args[2].(Waiter), args[3].(Sender))
+		run(args[0].(context.Context), args[1].([]byte), args[2].(Waiter), args[3].(Sender))
 	})
 	return _c
 }
@@ -79,7 +79,7 @@ func (_c *MockHandler_Handle_Call) Return(_a0 map[string]any, _a1 error) *MockHa
 	return _c
 }
 
-func (_c *MockHandler_Handle_Call) RunAndReturn(run func(context.Context, map[string]any, Waiter, Sender) (map[string]any, error)) *MockHandler_Handle_Call {
+func (_c *MockHandler_Handle_Call) RunAndReturn(run func(context.Context, []byte, Waiter, Sender) (map[string]any, error)) *MockHandler_Handle_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/core/processor/derivproc.go
+++ b/pkg/core/processor/derivproc.go
@@ -19,9 +19,9 @@ type DerivProc struct {
 }
 
 type templateData struct {
-	Params map[string]any `json:"params"`
-	Resp   map[string]any `json:"resp"`
-	ReqID  string         `json:"req_id"`
+	Resp   map[string]any  `json:"resp"`
+	ReqID  string          `json:"req_id"`
+	Params json.RawMessage `json:"params"`
 }
 
 type passthrough struct {
@@ -65,13 +65,13 @@ func (p *DerivProc) Name() string {
 // and two maps params and deps of type map[string]any.
 // It returns an error if the template execution fails.
 // If deps or params are nil, they are initialized as empty maps before template execution.
-func (p *DerivProc) Render(ctx context.Context, reqID string, params, deps map[string]any) (core.Request, error) {
+func (p *DerivProc) Render(ctx context.Context, reqID string, params []byte, deps map[string]any) (core.Request, error) {
 	if deps == nil {
 		deps = make(map[string]any)
 	}
 
 	if params == nil {
-		params = make(map[string]any)
+		params = []byte("{}")
 	}
 
 	data := templateData{

--- a/pkg/core/processor/derivproc_test.go
+++ b/pkg/core/processor/derivproc_test.go
@@ -67,17 +67,17 @@ func TestProcessor_Render(t *testing.T) {
 	tmpl2 := tmpl.MustNewTmpl(`{"params": "${params.key1.key2}}"}`)
 
 	tests := []struct {
-		params   map[string]any
 		deps     map[string]any
 		tmpl     *tmpl.Tmpl
 		name     string
 		expected string
 		reqID    string
+		params   []byte
 		wantErr  bool
 	}{
 		{
 			name:     "with params and deps",
-			params:   map[string]any{"key1": "value1"},
+			params:   []byte(`{"key1": "value1"}`),
 			deps:     map[string]any{"dep1": "value1"},
 			reqID:    "12345",
 			expected: `{"params":{"key1":"value1"},"req_id":"12345","resp": {"dep1":"value1"}}`,
@@ -93,7 +93,7 @@ func TestProcessor_Render(t *testing.T) {
 		},
 		{
 			name:     "with empty params and deps",
-			params:   map[string]any{},
+			params:   []byte(`{}`),
 			deps:     map[string]any{},
 			reqID:    "12345",
 			expected: `{"params":{},"req_id":"12345","resp": {}}`,
@@ -101,7 +101,7 @@ func TestProcessor_Render(t *testing.T) {
 		},
 		{
 			name:     "with only params",
-			params:   map[string]any{"key1": "value1"},
+			params:   []byte(`{"key1": "value1"}`),
 			deps:     nil,
 			reqID:    "12345",
 			expected: `{"params":{"key1":"value1"},"req_id":"12345","resp": {}}`,

--- a/pkg/core/processor/factory.go
+++ b/pkg/core/processor/factory.go
@@ -9,7 +9,7 @@ import (
 
 type Processor interface {
 	Name() string
-	Render(ctx context.Context, reqID string, params map[string]any, deps map[string]any) (core.Request, error)
+	Render(ctx context.Context, reqID string, params []byte, deps map[string]any) (core.Request, error)
 	Parse(data []byte) (resp, filetered map[string]any, err error)
 }
 

--- a/pkg/core/processor/httpproc.go
+++ b/pkg/core/processor/httpproc.go
@@ -72,7 +72,7 @@ func (p *HTTPProc) Name() string {
 // Render processes the HTTP request and writes the response.
 // It takes an io.Writer, an int64, and two maps of string to any type as parameters.
 // It returns an error indicating that the HTTP processor is not implemented.
-func (p *HTTPProc) Render(ctx context.Context, reqID string, param, deps map[string]any) (core.Request, error) {
+func (p *HTTPProc) Render(ctx context.Context, reqID string, param []byte, deps map[string]any) (core.Request, error) {
 	data := templateData{
 		Params: param,
 		Resp:   deps,

--- a/pkg/core/processor/httpproc_test.go
+++ b/pkg/core/processor/httpproc_test.go
@@ -218,7 +218,7 @@ func TestNewHTTP(t *testing.T) {
 func TestHTTPProc_Render(t *testing.T) {
 	tests := []struct {
 		proc        *HTTPProc
-		param       map[string]any
+		param       []byte
 		deps        map[string]any
 		wantHeaders map[string]string
 		name        string
@@ -237,7 +237,7 @@ func TestHTTPProc_Render(t *testing.T) {
 				headers:     map[string]*tmpl.StrTmpl{"Authorization": tmpl.MustNewStrTmpl("application/json")},
 			},
 			reqID:       "123",
-			param:       map[string]any{"param": "value"},
+			param:       []byte(`{"param":"value"}`),
 			deps:        map[string]any{},
 			wantURL:     "POST http://example.com/123",
 			wantBody:    []byte(`{"param": "value"}`),
@@ -254,7 +254,7 @@ func TestHTTPProc_Render(t *testing.T) {
 				headers:     map[string]*tmpl.StrTmpl{"Authorization": tmpl.MustNewStrTmpl("application/json")},
 			},
 			reqID:       "123",
-			param:       map[string]any{"param": "value"},
+			param:       []byte(`{"param": "value"}`),
 			deps:        map[string]any{},
 			wantURL:     "GET http://example.com/123",
 			wantBody:    nil,
@@ -270,7 +270,7 @@ func TestHTTPProc_Render(t *testing.T) {
 				tmpl:        nil,
 			},
 			reqID:       "123",
-			param:       map[string]any{"param": "value"},
+			param:       []byte(`{"param": "value"}`),
 			deps:        map[string]any{},
 			wantURL:     "",
 			wantBody:    nil,
@@ -286,7 +286,7 @@ func TestHTTPProc_Render(t *testing.T) {
 				tmpl:        tmpl.MustNewTmpl(`{"param": "${invalid_field}"}`),
 			},
 			reqID:       "123",
-			param:       map[string]any{"param": "value"},
+			param:       []byte(`{"param": "value"}`),
 			deps:        map[string]any{},
 			wantURL:     "POST http://example.com/123",
 			wantBody:    nil,
@@ -303,7 +303,7 @@ func TestHTTPProc_Render(t *testing.T) {
 				headers:     map[string]*tmpl.StrTmpl{"Authorization": tmpl.MustNewStrTmpl("Bearer ${params.token}")},
 			},
 			reqID:       "123",
-			param:       map[string]any{"param": "value", "token": "abc123"},
+			param:       []byte(`{"param": "value", "token": "abc123"}`),
 			deps:        map[string]any{},
 			wantURL:     "POST http://example.com/123",
 			wantBody:    []byte(`{"param": "value"}`),

--- a/pkg/core/request/request.go
+++ b/pkg/core/request/request.go
@@ -14,10 +14,10 @@ const (
 
 type Request struct {
 	ctx         context.Context
-	Params      map[string]any `json:"params"`
-	ID          *int           `json:"req_id"`
-	Method      string         `json:"method"`
-	PassThrough any            `json:"passthrough"`
+	Params      json.RawMessage `json:"params"`
+	ID          *int            `json:"req_id"`
+	Method      string          `json:"method"`
+	PassThrough any             `json:"passthrough"`
 	data        []byte
 }
 

--- a/pkg/core/svc.go
+++ b/pkg/core/svc.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/ksysoev/deriv-api-bff/pkg/core/request"
 	"github.com/ksysoev/wasabi"
@@ -22,7 +23,7 @@ type CallsRepo interface {
 }
 
 type Handler interface {
-	Handle(ctx context.Context, params []byte, watcher Waiter, send Sender) (map[string]any, error)
+	Handle(ctx context.Context, params json.RawMessage, watcher Waiter, send Sender) (map[string]any, error)
 }
 
 type ConnRegistry interface {

--- a/pkg/core/svc.go
+++ b/pkg/core/svc.go
@@ -22,7 +22,7 @@ type CallsRepo interface {
 }
 
 type Handler interface {
-	Handle(ctx context.Context, params map[string]any, watcher Waiter, send Sender) (map[string]any, error)
+	Handle(ctx context.Context, params []byte, watcher Waiter, send Sender) (map[string]any, error)
 }
 
 type ConnRegistry interface {

--- a/pkg/core/svc_test.go
+++ b/pkg/core/svc_test.go
@@ -63,7 +63,6 @@ func TestService_ProcessRequest(t *testing.T) {
 
 	mockHandler := NewMockHandler(t)
 	mockCallsRepo.EXPECT().GetCall("testMethod").Return(mockHandler)
-
 	mockHandler.EXPECT().Handle(
 		mock.Anything,
 		mockRequest.Params,

--- a/pkg/core/svc_test.go
+++ b/pkg/core/svc_test.go
@@ -111,7 +111,7 @@ func TestService_ProcessRequest_HandlerError(t *testing.T) {
 	mockConn := mocks.NewMockConnection(t)
 	mockRequest := &request.Request{
 		Method: "testMethod",
-		Params: map[string]any{"key": "value"},
+		Params: []byte(`{"key": "value"}`),
 	}
 
 	conn := NewConnection(mockConn, func(_ string) {})

--- a/pkg/core/validator/validator.go
+++ b/pkg/core/validator/validator.go
@@ -71,7 +71,7 @@ func (v *FieldValidator) Validate(data []byte) error {
 		return fmt.Errorf("failed to unmarshal params: %w", err)
 	}
 
-	err := v.jsonSchema.Validate(data)
+	err := v.jsonSchema.Validate(p)
 
 	var errValidation *jsonschema.ValidationError
 

--- a/pkg/core/validator/validator.go
+++ b/pkg/core/validator/validator.go
@@ -63,7 +63,14 @@ func New(cfg *Config) (*FieldValidator, error) {
 // It takes a single parameter data of type map[string]any which represents the data to be validated.
 // It returns an error if there are validation errors, including missing required fields or fields that are not allowed.
 // If the data contains fields not defined in the validator or if required fields are missing, it adds these errors to the validation error.
-func (v *FieldValidator) Validate(data map[string]any) error {
+func (v *FieldValidator) Validate(data []byte) error {
+	// TODO: Is it possible to find library to validate JSON schema against byte slice?
+	var p map[string]any
+
+	if err := json.Unmarshal(data, &p); err != nil {
+		return fmt.Errorf("failed to unmarshal params: %w", err)
+	}
+
 	err := v.jsonSchema.Validate(data)
 
 	var errValidation *jsonschema.ValidationError

--- a/pkg/core/validator/validator.go
+++ b/pkg/core/validator/validator.go
@@ -64,11 +64,15 @@ func New(cfg *Config) (*FieldValidator, error) {
 // It returns an error if there are validation errors, including missing required fields or fields that are not allowed.
 // If the data contains fields not defined in the validator or if required fields are missing, it adds these errors to the validation error.
 func (v *FieldValidator) Validate(data []byte) error {
-	// TODO: Is it possible to find library to validate JSON schema against byte slice?
 	var p map[string]any
 
-	if err := json.Unmarshal(data, &p); err != nil {
-		return fmt.Errorf("failed to unmarshal params: %w", err)
+	if data != nil {
+		// TODO: Is it possible to find library to validate JSON schema against byte slice?
+		if err := json.Unmarshal(data, &p); err != nil {
+			return fmt.Errorf("failed to unmarshal params: %w", err)
+		}
+	} else {
+		p = make(map[string]any)
 	}
 
 	err := v.jsonSchema.Validate(p)

--- a/pkg/core/validator/validator_test.go
+++ b/pkg/core/validator/validator_test.go
@@ -66,43 +66,28 @@ func TestFieldValidator_Validate(t *testing.T) {
 	}
 
 	tests := []struct {
-		data    map[string]any
 		name    string
+		data    []byte
 		wantErr bool
 	}{
 		{
-			name: "Valid data",
-			data: map[string]any{
-				"name":  "John",
-				"age":   30.0,
-				"admin": true,
-			},
+			name:    "Valid data",
+			data:    []byte(`{"name": "John", "age": 30, "admin": true}`),
 			wantErr: false,
 		},
 		{
-			name: "Missing field",
-			data: map[string]any{
-				"name": "John",
-			},
+			name:    "Missing field",
+			data:    []byte(`{"name": "John"}`),
 			wantErr: true,
 		},
 		{
-			name: "Extra field",
-			data: map[string]any{
-				"name":  "John",
-				"age":   30.0,
-				"admin": true,
-				"extra": "field",
-			},
+			name:    "Extra field",
+			data:    []byte(`{"name": "John", "age": 30, "admin": true, "extra": "field"}`),
 			wantErr: true,
 		},
 		{
-			name: "Invalid type",
-			data: map[string]any{
-				"name":  "John",
-				"age":   "thirty",
-				"admin": true,
-			},
+			name:    "Invalid type",
+			data:    []byte(`{"name": "John", "age": "thirty", "admin": true}`),
 			wantErr: true,
 		},
 	}
@@ -150,7 +135,7 @@ func TestFieldValidator_Validate_ErrorHandling(t *testing.T) {
 			}
 
 			mockSchema.EXPECT().Validate(map[string]any{}).Return(tt.err)
-			err := val.Validate(map[string]any{})
+			err := val.Validate([]byte(`{}`))
 
 			if tt.wantErr != nil {
 				assert.ErrorIs(t, err, tt.wantErr)

--- a/pkg/core/validator/validator_test.go
+++ b/pkg/core/validator/validator_test.go
@@ -90,6 +90,16 @@ func TestFieldValidator_Validate(t *testing.T) {
 			data:    []byte(`{"name": "John", "age": "thirty", "admin": true}`),
 			wantErr: true,
 		},
+		{
+			name:    "no params",
+			data:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "invalid json",
+			data:    []byte(`{`),
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Refactor the parameter handling in various interfaces and implementations to use a byte slice instead of a map, simplifying encoding and decoding processes. This change enhances performance by reducing multiple encodings.


kinda contributes to #100 