### PR TITLE
Refactor parsing logic to use json.RawMessage

### DIFF
--- a/pkg/core/composer/composer_test.go
+++ b/pkg/core/composer/composer_test.go
@@ -22,7 +22,7 @@ func makeParser(t *testing.T) func([]byte) (*response.Response, error) {
 			return nil, err
 		}
 
-		return response.New(res, res), nil
+		return response.New(data, res), nil
 	}
 }
 

--- a/pkg/core/composer/composer_test.go
+++ b/pkg/core/composer/composer_test.go
@@ -16,7 +16,7 @@ func makeParser(t *testing.T) func([]byte) (*response.Response, error) {
 	t.Helper()
 
 	return func(data []byte) (*response.Response, error) {
-		var res map[string]any
+		var res map[string]json.RawMessage
 
 		if err := json.Unmarshal(data, &res); err != nil {
 			return nil, err
@@ -51,7 +51,7 @@ func TestComposer_Success(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
-	assert.Equal(t, "param1,param2", resp["Params"])
+	assert.Equal(t, json.RawMessage(`"param1,param2"`), resp["Params"])
 }
 
 func TestComposer_Compose_ParseError(t *testing.T) {

--- a/pkg/core/processor/common.go
+++ b/pkg/core/processor/common.go
@@ -1,0 +1,51 @@
+package processor
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+)
+
+func prepareResp(data []byte) (map[string]json.RawMessage, error) {
+	if len(data) == 0 {
+		return nil, fmt.Errorf("response body not found")
+	}
+
+	switch data[0] {
+	case '{':
+		var respBody map[string]json.RawMessage
+
+		if err := json.Unmarshal(data, &respBody); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal response body: %w", err)
+		}
+
+		return respBody, nil
+	case '[':
+		return map[string]json.RawMessage{"list": data}, nil
+	default:
+		return map[string]json.RawMessage{"value": data}, nil
+	}
+}
+
+func filterResp(resp map[string]json.RawMessage, allow []string, fieldMap map[string]string) map[string]json.RawMessage {
+	filtered := make(map[string]json.RawMessage, len(allow))
+
+	for _, key := range allow {
+		if _, ok := resp[key]; !ok {
+			slog.Warn("Response body does not contain expeted key", slog.String("key", key))
+			continue
+		}
+
+		destKey := key
+
+		if fieldMap != nil {
+			if mappedKey, ok := fieldMap[key]; ok {
+				destKey = mappedKey
+			}
+		}
+
+		filtered[destKey] = resp[key]
+	}
+
+	return filtered
+}

--- a/pkg/core/processor/common.go
+++ b/pkg/core/processor/common.go
@@ -6,6 +6,10 @@ import (
 	"log/slog"
 )
 
+// prepareResp processes a byte slice representing a JSON response body and returns a map of JSON raw messages.
+// It takes data of type []byte.
+// It returns a map[string]json.RawMessage containing the parsed JSON data and an error if any occurs.
+// It returns an error if the data is empty or if the JSON unmarshalling fails.
 func prepareResp(data []byte) (map[string]json.RawMessage, error) {
 	if len(data) == 0 {
 		return nil, fmt.Errorf("response body not found")
@@ -27,6 +31,9 @@ func prepareResp(data []byte) (map[string]json.RawMessage, error) {
 	}
 }
 
+// filterResp filters the response map to include only allowed keys and maps them to new keys if specified.
+// It takes resp of type map[string]json.RawMessage, allow of type []string, and fieldMap of type map[string]string.
+// It returns a map[string]json.RawMessage containing only the allowed keys, optionally mapped to new keys.
 func filterResp(resp map[string]json.RawMessage, allow []string, fieldMap map[string]string) map[string]json.RawMessage {
 	filtered := make(map[string]json.RawMessage, len(allow))
 

--- a/pkg/core/processor/common_test.go
+++ b/pkg/core/processor/common_test.go
@@ -1,0 +1,135 @@
+package processor
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterResp(t *testing.T) {
+	tests := []struct {
+		resp     map[string]json.RawMessage
+		fieldMap map[string]string
+		expected map[string]json.RawMessage
+		name     string
+		allow    []string
+	}{
+		{
+			name: "filter with allowed keys",
+			resp: map[string]json.RawMessage{
+				"key1": json.RawMessage(`"value1"`),
+				"key2": json.RawMessage(`"value2"`),
+				"key3": json.RawMessage(`"value3"`),
+			},
+			allow: []string{"key1", "key3"},
+			expected: map[string]json.RawMessage{
+				"key1": json.RawMessage(`"value1"`),
+				"key3": json.RawMessage(`"value3"`),
+			},
+		},
+		{
+			name: "filter with field map",
+			resp: map[string]json.RawMessage{
+				"key1": json.RawMessage(`"value1"`),
+				"key2": json.RawMessage(`"value2"`),
+			},
+			allow: []string{"key1", "key2"},
+			fieldMap: map[string]string{
+				"key1": "newKey1",
+				"key2": "newKey2",
+			},
+			expected: map[string]json.RawMessage{
+				"newKey1": json.RawMessage(`"value1"`),
+				"newKey2": json.RawMessage(`"value2"`),
+			},
+		},
+		{
+			name: "filter with missing keys",
+			resp: map[string]json.RawMessage{
+				"key1": json.RawMessage(`"value1"`),
+			},
+			allow: []string{"key1", "key2"},
+			expected: map[string]json.RawMessage{
+				"key1": json.RawMessage(`"value1"`),
+			},
+		},
+		{
+			name: "filter with empty allow list",
+			resp: map[string]json.RawMessage{
+				"key1": json.RawMessage(`"value1"`),
+				"key2": json.RawMessage(`"value2"`),
+			},
+			allow:    []string{},
+			expected: map[string]json.RawMessage{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterResp(tt.resp, tt.allow, tt.fieldMap)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+func TestPrepareResp(t *testing.T) {
+	tests := []struct {
+		err      error
+		expected map[string]json.RawMessage
+		name     string
+		data     []byte
+	}{
+		{
+			name: "valid JSON object",
+			data: []byte(`{"key1":"value1","key2":"value2"}`),
+			expected: map[string]json.RawMessage{
+				"key1": json.RawMessage(`"value1"`),
+				"key2": json.RawMessage(`"value2"`),
+			},
+			err: nil,
+		},
+		{
+			name: "valid JSON array",
+			data: []byte(`["value1","value2"]`),
+			expected: map[string]json.RawMessage{
+				"list": json.RawMessage(`["value1","value2"]`),
+			},
+			err: nil,
+		},
+		{
+			name: "valid JSON value",
+			data: []byte(`"value1"`),
+			expected: map[string]json.RawMessage{
+				"value": json.RawMessage(`"value1"`),
+			},
+			err: nil,
+		},
+		{
+			name:     "empty data",
+			data:     []byte(``),
+			expected: nil,
+			err:      fmt.Errorf("response body not found"),
+		},
+		{
+			name:     "invalid JSON",
+			data:     []byte(`{key1:value1}`),
+			expected: nil,
+			err:      fmt.Errorf("failed to unmarshal response body: invalid character 'k' looking for beginning of object key string"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := prepareResp(tt.data)
+			if tt.err != nil {
+				assert.Error(t, err)
+				assert.EqualError(t, err, tt.err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/core/processor/derivproc.go
+++ b/pkg/core/processor/derivproc.go
@@ -88,13 +88,10 @@ func (p *DerivProc) Render(ctx context.Context, reqID string, params []byte, dep
 	return request.NewRequest(ctx, request.TextMessage, req), nil
 }
 
-// Parse processes the input data and filters the response based on allowed keys.
+// Parse processes the input data and returns a parsed and filtered response.
 // It takes data of type []byte.
-// It returns three values: resp which is a map[string]any containing the parsed response,
-// filetered which is a map[string]any containing the filtered response based on allowed keys,
-// and an error if the parsing fails.
-// It returns an error if the input data cannot be parsed.
-// Edge case: If the response does not contain an expected key, a warning is logged and the key is skipped.
+// It returns a pointer to response.Response and an error.
+// It returns an error if parsing or preparing the response fails.
 func (p *DerivProc) Parse(data []byte) (*response.Response, error) {
 	resp, err := p.parse(data)
 	if err != nil {
@@ -111,12 +108,11 @@ func (p *DerivProc) Parse(data []byte) (*response.Response, error) {
 	return response.New(resp, filetered), nil
 }
 
-// parse unmarshals JSON data into a map and processes the response body.
-// It takes data of type []byte and returns a map[string]any and an error.
-// It returns an error if the JSON unmarshalling fails, if the response contains an error,
-// or if the response body is not found or is in an unexpected format.
-// If the response body is a map, it returns it directly. If it is a list, it wraps it in a map with the key "list".
-// If it is any other type, it wraps it in a map with the key "value".
+// parse parses the given JSON data and extracts the relevant message body.
+// It takes data of type []byte which is the JSON data to be parsed.
+// It returns a json.RawMessage containing the extracted message body and an error if any occurs.
+// It returns an error if the JSON data cannot be unmarshaled, if the "error" field is present in the data,
+// if the "msg_type" field is missing or not a valid string, or if the response body corresponding to the msg_type is not found.
 func (p *DerivProc) parse(data []byte) (json.RawMessage, error) {
 	var rdata map[string]json.RawMessage
 

--- a/pkg/core/processor/derivproc.go
+++ b/pkg/core/processor/derivproc.go
@@ -146,6 +146,7 @@ func (p *DerivProc) parse(data []byte) (map[string]json.RawMessage, error) {
 	if !ok {
 		return nil, fmt.Errorf("msg_type not found or not a string")
 	}
+
 	if len(msgTypeRaw) < 3 || msgTypeRaw[0] != '"' || msgTypeRaw[len(msgTypeRaw)-1] != '"' {
 		return nil, fmt.Errorf("msg_type not a valid string")
 	}
@@ -160,8 +161,8 @@ func (p *DerivProc) parse(data []byte) (map[string]json.RawMessage, error) {
 	switch rb[0] {
 	case '{':
 		var respBody map[string]json.RawMessage
-		err := json.Unmarshal(rb, &respBody)
-		if err != nil {
+
+		if err := json.Unmarshal(rb, &respBody); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal response body: %w", err)
 		}
 

--- a/pkg/core/processor/derivproc_test.go
+++ b/pkg/core/processor/derivproc_test.go
@@ -2,6 +2,7 @@ package processor
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/ksysoev/deriv-api-bff/pkg/core/tmpl"
@@ -152,24 +153,24 @@ func TestProcessor_Render(t *testing.T) {
 
 func TestProcessor_parse_Success(t *testing.T) {
 	tests := []struct {
-		expected map[string]any
+		expected map[string]json.RawMessage
 		name     string
 		jsonData string
 	}{
 		{
 			name:     "object",
 			jsonData: `{"data": {"key1": "value1", "key2": "value2"}, "msg_type": "data"}`,
-			expected: map[string]any{"key1": "value1", "key2": "value2"},
+			expected: map[string]json.RawMessage{"key1": []byte(`"value1"`), "key2": []byte(`"value2"`)},
 		},
 		{
 			name:     "array",
 			jsonData: `{"data": [{"key1": "value1"}, {"key2": "value2"}], "msg_type": "data"}`,
-			expected: map[string]any{"list": []any{map[string]any{"key1": "value1"}, map[string]any{"key2": "value2"}}},
+			expected: map[string]json.RawMessage{"list": []byte(`[{"key1": "value1"}, {"key2": "value2"}]`)},
 		},
 		{
 			name:     "scalar",
 			jsonData: `{"data": "value", "msg_type": "data"}`,
-			expected: map[string]any{"value": "value"},
+			expected: map[string]json.RawMessage{"value": []byte(`"value"`)},
 		},
 	}
 

--- a/pkg/core/processor/derivproc_test.go
+++ b/pkg/core/processor/derivproc_test.go
@@ -215,7 +215,7 @@ func TestProcessor_parse_UnexpectedFormat(t *testing.T) {
 func TestProcessor_Parse_Success(t *testing.T) {
 	tests := []struct {
 		fieldMap map[string]string
-		expected map[string]any
+		expected map[string]json.RawMessage
 		name     string
 		jsonData string
 		allow    []string
@@ -225,21 +225,21 @@ func TestProcessor_Parse_Success(t *testing.T) {
 			fieldMap: map[string]string{"key1": "mappedKey1"},
 			allow:    []string{"key1", "key2"},
 			jsonData: `{"data": {"key1": "value1", "key2": "value2"}, "msg_type": "data"}`,
-			expected: map[string]any{"mappedKey1": "value1", "key2": "value2"},
+			expected: map[string]json.RawMessage{"mappedKey1": []byte(`"value1"`), "key2": []byte(`"value2"`)},
 		},
 		{
 			name:     "allowed fields without field mapping",
 			fieldMap: nil,
 			allow:    []string{"key1", "key2"},
 			jsonData: `{"data": {"key1": "value1", "key2": "value2"}, "msg_type": "data"}`,
-			expected: map[string]any{"key1": "value1", "key2": "value2"},
+			expected: map[string]json.RawMessage{"key1": []byte(`"value1"`), "key2": []byte(`"value2"`)},
 		},
 		{
 			name:     "missing allowed fields",
 			fieldMap: nil,
 			allow:    []string{"key3"},
 			jsonData: `{"data": {"key1": "value1", "key2": "value2"}, "msg_type": "data"}`,
-			expected: map[string]any{},
+			expected: map[string]json.RawMessage{},
 		},
 	}
 

--- a/pkg/core/processor/derivproc_test.go
+++ b/pkg/core/processor/derivproc_test.go
@@ -153,9 +153,9 @@ func TestProcessor_Render(t *testing.T) {
 
 func TestProcessor_parse_Success(t *testing.T) {
 	tests := []struct {
-		expected json.RawMessage
 		name     string
 		jsonData string
+		expected json.RawMessage
 	}{
 		{
 			name:     "object",

--- a/pkg/core/processor/derivproc_test.go
+++ b/pkg/core/processor/derivproc_test.go
@@ -153,24 +153,24 @@ func TestProcessor_Render(t *testing.T) {
 
 func TestProcessor_parse_Success(t *testing.T) {
 	tests := []struct {
-		expected map[string]json.RawMessage
+		expected json.RawMessage
 		name     string
 		jsonData string
 	}{
 		{
 			name:     "object",
 			jsonData: `{"data": {"key1": "value1", "key2": "value2"}, "msg_type": "data"}`,
-			expected: map[string]json.RawMessage{"key1": []byte(`"value1"`), "key2": []byte(`"value2"`)},
+			expected: json.RawMessage(`{"key1": "value1", "key2": "value2"}`),
 		},
 		{
 			name:     "array",
 			jsonData: `{"data": [{"key1": "value1"}, {"key2": "value2"}], "msg_type": "data"}`,
-			expected: map[string]json.RawMessage{"list": []byte(`[{"key1": "value1"}, {"key2": "value2"}]`)},
+			expected: json.RawMessage(`[{"key1": "value1"}, {"key2": "value2"}]`),
 		},
 		{
 			name:     "scalar",
 			jsonData: `{"data": "value", "msg_type": "data"}`,
-			expected: map[string]json.RawMessage{"value": []byte(`"value"`)},
+			expected: json.RawMessage(`"value"`),
 		},
 	}
 

--- a/pkg/core/processor/error_test.go
+++ b/pkg/core/processor/error_test.go
@@ -10,8 +10,8 @@ import (
 func TestNewAPIError(t *testing.T) {
 	tests := []struct {
 		name   string
-		data   json.RawMessage
 		errMsg string
+		data   json.RawMessage
 	}{
 		{
 			name:   "Valid data",

--- a/pkg/core/processor/error_test.go
+++ b/pkg/core/processor/error_test.go
@@ -1,6 +1,7 @@
 package processor
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,33 +10,28 @@ import (
 func TestNewAPIError(t *testing.T) {
 	tests := []struct {
 		name   string
-		data   any
+		data   json.RawMessage
 		errMsg string
 	}{
 		{
 			name:   "Valid data",
-			data:   map[string]any{"code": "400", "message": "Bad Request", "details": map[string]any{"field": "value"}},
+			data:   []byte(`{"code": "400", "message": "Bad Request", "details": {"field": "value"}}`),
 			errMsg: "Bad Request",
 		},
 		{
 			name:   "Invalid data format",
-			data:   "invalid data",
-			errMsg: "error data is not in expected format",
+			data:   []byte(`invalid data`),
+			errMsg: "failed to unmarshal APIError data: invalid character 'i' looking for beginning of value",
 		},
 		{
 			name:   "Missing code",
-			data:   map[string]any{"message": "Bad Request"},
-			errMsg: "error code is not in expected format",
-		},
-		{
-			name:   "Missing message",
-			data:   map[string]any{"code": "400"},
+			data:   []byte(`{"message": "Bad Request"}`),
 			errMsg: "error message is not in expected format",
 		},
 		{
-			name:   "Invalid details",
-			data:   map[string]any{"code": "400", "message": "Bad Request", "details": make(chan int)},
-			errMsg: "failed to marshal APIError details: json: unsupported type: chan int",
+			name:   "Missing message",
+			data:   []byte(`{"code": "400"}`),
+			errMsg: "error message is not in expected format",
 		},
 	}
 

--- a/pkg/core/processor/errors.go
+++ b/pkg/core/processor/errors.go
@@ -13,10 +13,9 @@ type errorData struct {
 	Details json.RawMessage `json:"details,omitempty"`
 }
 
-// NewAPIError creates a new API error from the provided data.
-// It takes a single parameter data of type any, which is expected to be a map with keys "code", "message", and optionally "details".
-// It returns an error which is an instance of core.APIError if the data is in the expected format, or a descriptive error if the data format is incorrect.
-// It returns an error if the data is not a map, if the "code" or "message" fields are missing or not strings, or if the "details" field cannot be marshaled to JSON.
+// NewAPIError creates a new API error from the provided JSON data.
+// It takes a single parameter data of type json.RawMessage.
+// It returns an error if the JSON data cannot be unmarshaled or if the error message is not in the expected format.
 func NewAPIError(data json.RawMessage) error {
 	var errData errorData
 

--- a/pkg/core/processor/errors.go
+++ b/pkg/core/processor/errors.go
@@ -7,36 +7,26 @@ import (
 	"github.com/ksysoev/deriv-api-bff/pkg/core"
 )
 
+type errorData struct {
+	Code    string          `json:"code"`
+	Message string          `json:"message"`
+	Details json.RawMessage `json:"details,omitempty"`
+}
+
 // NewAPIError creates a new API error from the provided data.
 // It takes a single parameter data of type any, which is expected to be a map with keys "code", "message", and optionally "details".
 // It returns an error which is an instance of core.APIError if the data is in the expected format, or a descriptive error if the data format is incorrect.
 // It returns an error if the data is not a map, if the "code" or "message" fields are missing or not strings, or if the "details" field cannot be marshaled to JSON.
-func NewAPIError(data any) error {
-	err, ok := data.(map[string]any)
-	if !ok {
-		return fmt.Errorf("error data is not in expected format")
+func NewAPIError(data json.RawMessage) error {
+	var errData errorData
+
+	if err := json.Unmarshal(data, &errData); err != nil {
+		return fmt.Errorf("failed to unmarshal APIError data: %w", err)
 	}
 
-	code, ok := err["code"].(string)
-	if !ok {
-		return fmt.Errorf("error code is not in expected format")
-	}
-
-	message, ok := err["message"].(string)
-	if !ok {
+	if errData.Code == "" || errData.Message == "" {
 		return fmt.Errorf("error message is not in expected format")
 	}
 
-	var detailsData json.RawMessage
-
-	if details, ok := err["details"]; ok {
-		var err error
-
-		detailsData, err = json.Marshal(details)
-		if err != nil {
-			return fmt.Errorf("failed to marshal APIError details: %w", err)
-		}
-	}
-
-	return core.NewAPIError(code, message, detailsData)
+	return core.NewAPIError(errData.Code, errData.Message, errData.Details)
 }

--- a/pkg/core/processor/httpproc.go
+++ b/pkg/core/processor/httpproc.go
@@ -143,10 +143,15 @@ func (p *HTTPProc) parse(data []byte) (json.RawMessage, error) {
 		return nil, fmt.Errorf("response body not found")
 	}
 
-	if data[0] == '{' {
+	var jsonData json.RawMessage
+	if err := json.Unmarshal(data, &jsonData); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response body: %w", err)
+	}
+
+	if jsonData[0] == '{' {
 		var errRaw errData
 
-		if err := json.Unmarshal(data, &errRaw); err != nil {
+		if err := json.Unmarshal(jsonData, &errRaw); err != nil {
 			return nil, fmt.Errorf("fail to parse response: %s", err)
 		}
 
@@ -155,5 +160,5 @@ func (p *HTTPProc) parse(data []byte) (json.RawMessage, error) {
 		}
 	}
 
-	return data, nil
+	return jsonData, nil
 }

--- a/pkg/core/processor/httpproc.go
+++ b/pkg/core/processor/httpproc.go
@@ -148,7 +148,7 @@ func (p *HTTPProc) parse(data []byte) (json.RawMessage, error) {
 		var errRaw errData
 
 		if err := json.Unmarshal(data, &errRaw); err != nil {
-			return nil, fmt.Errorf("Fail to parse response: %s", err)
+			return nil, fmt.Errorf("fail to parse response: %s", err)
 		}
 
 		if errRaw.Err != nil {

--- a/pkg/core/processor/httpproc.go
+++ b/pkg/core/processor/httpproc.go
@@ -103,8 +103,6 @@ func (p *HTTPProc) Render(ctx context.Context, reqID string, param []byte, deps 
 				return nil, fmt.Errorf("fail to execute header template %s: %w", key, err)
 			}
 
-			fmt.Println("headerValue", headerValue)
-
 			req.AddHeader(key, headerValue)
 		}
 	}

--- a/pkg/core/processor/httpproc.go
+++ b/pkg/core/processor/httpproc.go
@@ -113,10 +113,10 @@ func (p *HTTPProc) Render(ctx context.Context, reqID string, param []byte, deps 
 	return req, nil
 }
 
-// Parse processes the input data and filters the response based on allowed keys.
-// It takes data of type []byte and returns two maps: resp and filetered, both of type map[string]any, and an error if parsing fails.
-// It returns an error if the input data cannot be parsed.
-// Edge cases include missing expected keys in the response, which are logged as warnings.
+// Parse processes the given byte slice and returns a parsed response.
+// It takes data of type []byte.
+// It returns a pointer to response.Response and an error.
+// It returns an error if parsing or preparing the response fails.
 func (p *HTTPProc) Parse(data []byte) (*response.Response, error) {
 	resp, err := p.parse(data)
 	if err != nil {
@@ -133,12 +133,11 @@ func (p *HTTPProc) Parse(data []byte) (*response.Response, error) {
 	return response.New(resp, filetered), nil
 }
 
-// parse parses the given JSON data and returns it as a map[string]any.
-// It takes a single parameter data of type []byte which is the JSON data to be parsed.
-// It returns a map[string]any representing the parsed JSON data and an error if the parsing fails.
-// It returns an error if the JSON data is malformed or if the response body is in an unexpected format.
-// If the JSON data is an array, it wraps it in a map with the key "list".
-// If the JSON data is a single value, it wraps it in a map with the key "value".
+// parse parses the given byte slice as JSON and returns a json.RawMessage.
+// It takes data of type []byte.
+// It returns a json.RawMessage and an error.
+// It returns an error if the data is empty, if the data cannot be unmarshaled, or if the unmarshaled data contains an error.
+// If the data starts with '{', it attempts to unmarshal it into an errData struct and checks for an error field.
 func (p *HTTPProc) parse(data []byte) (json.RawMessage, error) {
 	if len(data) == 0 {
 		return nil, fmt.Errorf("response body not found")

--- a/pkg/core/processor/httpproc.go
+++ b/pkg/core/processor/httpproc.go
@@ -152,8 +152,8 @@ func (p *HTTPProc) parse(data []byte) (map[string]json.RawMessage, error) {
 	switch data[0] {
 	case '{':
 		var respBody map[string]json.RawMessage
-		err := json.Unmarshal(data, &respBody)
-		if err != nil {
+
+		if err := json.Unmarshal(data, &respBody); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal response body: %w", err)
 		}
 

--- a/pkg/core/processor/httpproc_test.go
+++ b/pkg/core/processor/httpproc_test.go
@@ -353,6 +353,25 @@ func TestHTTPProc_parse(t *testing.T) {
 			want:    []byte(`{"key1": "value1", "key2": 2}`),
 			wantErr: false,
 		},
+
+		{
+			name:    "Valid JSON object with spaces",
+			data:    []byte(` {"key1": "value1", "key2": 2}`),
+			want:    []byte(`{"key1": "value1", "key2": 2}`),
+			wantErr: false,
+		},
+		{
+			name:    "Invalid JSON object",
+			data:    []byte(`{"key1": "value1", "key2": 2`),
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "Empty body",
+			data:    []byte(``),
+			want:    nil,
+			wantErr: true,
+		},
 		{
 			name:    "Valid JSON array",
 			data:    []byte(`[{"key1": "value1"}, {"key2": 2}]`),

--- a/pkg/core/processor/httpproc_test.go
+++ b/pkg/core/processor/httpproc_test.go
@@ -14,7 +14,7 @@ import (
 func TestHTTPProc_Parse(t *testing.T) {
 	tests := []struct {
 		fieldMap map[string]string
-		wantResp map[string]json.RawMessage
+		wantResp json.RawMessage
 		wantFilt map[string]json.RawMessage
 		name     string
 		data     []byte
@@ -26,7 +26,7 @@ func TestHTTPProc_Parse(t *testing.T) {
 			data:     []byte(`{"key1": "value1", "key2": 2}`),
 			allow:    []string{"key1", "key2"},
 			fieldMap: nil,
-			wantResp: map[string]json.RawMessage{"key1": []byte(`"value1"`), "key2": []byte("2")},
+			wantResp: json.RawMessage(`{"key1": "value1", "key2": 2}`),
 			wantFilt: map[string]json.RawMessage{"key1": []byte(`"value1"`), "key2": []byte("2")},
 			wantErr:  false,
 		},
@@ -35,7 +35,7 @@ func TestHTTPProc_Parse(t *testing.T) {
 			data:     []byte(`{"key1": "value1", "key2": 2}`),
 			allow:    []string{"key1", "key2"},
 			fieldMap: map[string]string{"key1": "mappedKey1"},
-			wantResp: map[string]json.RawMessage{"key1": []byte(`"value1"`), "key2": []byte("2")},
+			wantResp: json.RawMessage(`{"key1": "value1", "key2": 2}`),
 			wantFilt: map[string]json.RawMessage{"mappedKey1": []byte(`"value1"`), "key2": []byte("2")},
 			wantErr:  false,
 		},
@@ -44,7 +44,7 @@ func TestHTTPProc_Parse(t *testing.T) {
 			data:     []byte(`{"key1": "value1"}`),
 			allow:    []string{"key1", "key2"},
 			fieldMap: nil,
-			wantResp: map[string]json.RawMessage{"key1": []byte(`"value1"`)},
+			wantResp: json.RawMessage(`{"key1": "value1"}`),
 			wantFilt: map[string]json.RawMessage{"key1": []byte(`"value1"`)},
 			wantErr:  false,
 		},
@@ -62,7 +62,7 @@ func TestHTTPProc_Parse(t *testing.T) {
 			data:     []byte(`123`),
 			allow:    []string{"value"},
 			fieldMap: nil,
-			wantResp: map[string]json.RawMessage{"value": []byte("123")},
+			wantResp: []byte(`123`),
 			wantFilt: map[string]json.RawMessage{"value": []byte("123")},
 			wantErr:  false,
 		},
@@ -342,7 +342,7 @@ func TestHTTPProc_Render(t *testing.T) {
 
 func TestHTTPProc_parse(t *testing.T) {
 	tests := []struct {
-		want    map[string]json.RawMessage
+		want    json.RawMessage
 		name    string
 		data    []byte
 		wantErr bool
@@ -350,19 +350,19 @@ func TestHTTPProc_parse(t *testing.T) {
 		{
 			name:    "Valid JSON object",
 			data:    []byte(`{"key1": "value1", "key2": 2}`),
-			want:    map[string]json.RawMessage{"key1": []byte(`"value1"`), "key2": []byte("2")},
+			want:    []byte(`{"key1": "value1", "key2": 2}`),
 			wantErr: false,
 		},
 		{
 			name:    "Valid JSON array",
 			data:    []byte(`[{"key1": "value1"}, {"key2": 2}]`),
-			want:    map[string]json.RawMessage{"list": []byte(`[{"key1": "value1"}, {"key2": 2}]`)},
+			want:    []byte(`[{"key1": "value1"}, {"key2": 2}]`),
 			wantErr: false,
 		},
 		{
 			name:    "Valid single JSON value",
 			data:    []byte(`"singleValue"`),
-			want:    map[string]json.RawMessage{"value": []byte(`"singleValue"`)},
+			want:    []byte(`"singleValue"`),
 			wantErr: false,
 		},
 		{
@@ -372,9 +372,9 @@ func TestHTTPProc_parse(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "Unexpected format",
+			name:    "Value ",
 			data:    []byte(`123`),
-			want:    map[string]json.RawMessage{"value": []byte("123")},
+			want:    []byte(`123`),
 			wantErr: false,
 		},
 		{

--- a/pkg/core/processor/httpproc_test.go
+++ b/pkg/core/processor/httpproc_test.go
@@ -2,6 +2,7 @@ package processor
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/ksysoev/deriv-api-bff/pkg/core/request"
@@ -13,8 +14,8 @@ import (
 func TestHTTPProc_Parse(t *testing.T) {
 	tests := []struct {
 		fieldMap map[string]string
-		wantResp map[string]any
-		wantFilt map[string]any
+		wantResp map[string]json.RawMessage
+		wantFilt map[string]json.RawMessage
 		name     string
 		data     []byte
 		allow    []string
@@ -25,8 +26,8 @@ func TestHTTPProc_Parse(t *testing.T) {
 			data:     []byte(`{"key1": "value1", "key2": 2}`),
 			allow:    []string{"key1", "key2"},
 			fieldMap: nil,
-			wantResp: map[string]any{"key1": "value1", "key2": 2.0},
-			wantFilt: map[string]any{"key1": "value1", "key2": 2.0},
+			wantResp: map[string]json.RawMessage{"key1": []byte(`"value1"`), "key2": []byte("2")},
+			wantFilt: map[string]json.RawMessage{"key1": []byte(`"value1"`), "key2": []byte("2")},
 			wantErr:  false,
 		},
 		{
@@ -34,8 +35,8 @@ func TestHTTPProc_Parse(t *testing.T) {
 			data:     []byte(`{"key1": "value1", "key2": 2}`),
 			allow:    []string{"key1", "key2"},
 			fieldMap: map[string]string{"key1": "mappedKey1"},
-			wantResp: map[string]any{"key1": "value1", "key2": 2.0},
-			wantFilt: map[string]any{"mappedKey1": "value1", "key2": 2.0},
+			wantResp: map[string]json.RawMessage{"key1": []byte(`"value1"`), "key2": []byte("2")},
+			wantFilt: map[string]json.RawMessage{"mappedKey1": []byte(`"value1"`), "key2": []byte("2")},
 			wantErr:  false,
 		},
 		{
@@ -43,8 +44,8 @@ func TestHTTPProc_Parse(t *testing.T) {
 			data:     []byte(`{"key1": "value1"}`),
 			allow:    []string{"key1", "key2"},
 			fieldMap: nil,
-			wantResp: map[string]any{"key1": "value1"},
-			wantFilt: map[string]any{"key1": "value1"},
+			wantResp: map[string]json.RawMessage{"key1": []byte(`"value1"`)},
+			wantFilt: map[string]json.RawMessage{"key1": []byte(`"value1"`)},
 			wantErr:  false,
 		},
 		{
@@ -61,8 +62,8 @@ func TestHTTPProc_Parse(t *testing.T) {
 			data:     []byte(`123`),
 			allow:    []string{"value"},
 			fieldMap: nil,
-			wantResp: map[string]any{"value": 123.0},
-			wantFilt: map[string]any{"value": 123.0},
+			wantResp: map[string]json.RawMessage{"value": []byte("123")},
+			wantFilt: map[string]json.RawMessage{"value": []byte("123")},
 			wantErr:  false,
 		},
 	}
@@ -341,7 +342,7 @@ func TestHTTPProc_Render(t *testing.T) {
 
 func TestHTTPProc_parse(t *testing.T) {
 	tests := []struct {
-		want    map[string]any
+		want    map[string]json.RawMessage
 		name    string
 		data    []byte
 		wantErr bool
@@ -349,19 +350,19 @@ func TestHTTPProc_parse(t *testing.T) {
 		{
 			name:    "Valid JSON object",
 			data:    []byte(`{"key1": "value1", "key2": 2}`),
-			want:    map[string]any{"key1": "value1", "key2": 2.0},
+			want:    map[string]json.RawMessage{"key1": []byte(`"value1"`), "key2": []byte("2")},
 			wantErr: false,
 		},
 		{
 			name:    "Valid JSON array",
 			data:    []byte(`[{"key1": "value1"}, {"key2": 2}]`),
-			want:    map[string]any{"list": []any{map[string]any{"key1": "value1"}, map[string]any{"key2": 2.0}}},
+			want:    map[string]json.RawMessage{"list": []byte(`[{"key1": "value1"}, {"key2": 2}]`)},
 			wantErr: false,
 		},
 		{
 			name:    "Valid single JSON value",
 			data:    []byte(`"singleValue"`),
-			want:    map[string]any{"value": "singleValue"},
+			want:    map[string]json.RawMessage{"value": []byte(`"singleValue"`)},
 			wantErr: false,
 		},
 		{
@@ -373,7 +374,7 @@ func TestHTTPProc_parse(t *testing.T) {
 		{
 			name:    "Unexpected format",
 			data:    []byte(`123`),
-			want:    map[string]any{"value": 123.0},
+			want:    map[string]json.RawMessage{"value": []byte("123")},
 			wantErr: false,
 		},
 		{

--- a/pkg/core/response.go
+++ b/pkg/core/response.go
@@ -8,6 +8,14 @@ import (
 	"github.com/ksysoev/deriv-api-bff/pkg/core/request"
 )
 
+// createResponse constructs a response based on the provided request, response data, and error.
+// It takes req of type *request.Request, respData of type map[string]any, and err of type error.
+// It returns a byte slice containing the marshaled response and an error if any occurs during processing.
+// It returns an error if the request handling fails or if the response marshaling fails.
+// If err is of type *APIError, it includes the encoded error in the response.
+// If req.ID is not nil, it includes the request ID in the response.
+// If req.PassThrough is not nil, it includes the passthrough data in the response.
+// The response includes an "echo" field containing the raw request data.
 func createResponse(req *request.Request, respData map[string]any, err error) ([]byte, error) {
 	var apiErr *APIError
 

--- a/pkg/core/response/resp.go
+++ b/pkg/core/response/resp.go
@@ -1,21 +1,23 @@
 package response
 
+import "encoding/json"
+
 type Response struct {
-	filtered map[string]any
-	data     map[string]any
+	filtered map[string]json.RawMessage
+	data     map[string]json.RawMessage
 }
 
-func New(data, filtered map[string]any) *Response {
+func New(data, filtered map[string]json.RawMessage) *Response {
 	return &Response{
 		data:     data,
 		filtered: filtered,
 	}
 }
 
-func (r *Response) Body() map[string]any {
+func (r *Response) Body() map[string]json.RawMessage {
 	return r.data
 }
 
-func (r *Response) Filtered() map[string]any {
+func (r *Response) Filtered() map[string]json.RawMessage {
 	return r.filtered
 }

--- a/pkg/core/response/resp.go
+++ b/pkg/core/response/resp.go
@@ -9,6 +9,9 @@ type Response struct {
 	data     json.RawMessage
 }
 
+// New creates a new Response instance with the provided data and filtered map.
+// It takes data of type json.RawMessage and filtered of type map[string]json.RawMessage.
+// It returns a pointer to a Response struct.
 func New(data json.RawMessage, filtered map[string]json.RawMessage) *Response {
 	return &Response{
 		data:     data,
@@ -16,10 +19,12 @@ func New(data json.RawMessage, filtered map[string]json.RawMessage) *Response {
 	}
 }
 
+// Body returns the body of the Response as a json.RawMessage.
 func (r *Response) Body() json.RawMessage {
 	return r.data
 }
 
+// Filtered returns the filtered response as a map of strings to json.RawMessage.
 func (r *Response) Filtered() map[string]json.RawMessage {
 	return r.filtered
 }

--- a/pkg/core/response/resp.go
+++ b/pkg/core/response/resp.go
@@ -1,20 +1,22 @@
 package response
 
-import "encoding/json"
+import (
+	"encoding/json"
+)
 
 type Response struct {
 	filtered map[string]json.RawMessage
-	data     map[string]json.RawMessage
+	data     json.RawMessage
 }
 
-func New(data, filtered map[string]json.RawMessage) *Response {
+func New(data json.RawMessage, filtered map[string]json.RawMessage) *Response {
 	return &Response{
 		data:     data,
 		filtered: filtered,
 	}
 }
 
-func (r *Response) Body() map[string]json.RawMessage {
+func (r *Response) Body() json.RawMessage {
 	return r.data
 }
 


### PR DESCRIPTION
Refactor the parsing logic to utilize `json.RawMessage` for improved performance and flexibility. Update tests accordingly to reflect these changes.