### PR TITLE
Implement configuration saving functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ Upload the API call configuration to the remote source (e.g., etcd):
 bff config upload --config=./config.yaml
 ```
 
+### Config Download
+
+Download the API call configurration from remote source to requested file
+
+```sh
+bff config upload --config=./config.yaml --output=./myconfig.yaml
+```
+
 ## Command Line Arguments
 
 Each command supports the following arguments:

--- a/pkg/cmd/cfg.go
+++ b/pkg/cmd/cfg.go
@@ -104,6 +104,9 @@ func verifyConfig(ctx context.Context, cfg *Config) error {
 	return nil
 }
 
+// downloadConfig downloads the configuration from a specified source and writes it to a given path.
+// It takes a context.Context, a pointer to Config, and a string representing the path to write the configuration.
+// It returns an error if there is a failure in creating the config source, creating the config service, or writing the config.
 func downloadConfig(ctx context.Context, cfg *Config, path string) error {
 	sourceOpts, err := source.CreateOptions(&cfg.APISource)
 	if err != nil {

--- a/pkg/cmd/cfg.go
+++ b/pkg/cmd/cfg.go
@@ -104,6 +104,28 @@ func verifyConfig(ctx context.Context, cfg *Config) error {
 	return nil
 }
 
+func downloadConfig(ctx context.Context, cfg *Config, path string) error {
+	sourceOpts, err := source.CreateOptions(&cfg.APISource)
+	if err != nil {
+		return fmt.Errorf("failed to create config source: %w", err)
+	}
+
+	calls := repo.NewCallsRepository()
+	requestHandler := core.NewService(calls, nil, nil)
+
+	svc, err := config.New(requestHandler, sourceOpts...)
+	if err != nil {
+		return fmt.Errorf("failed to create config service: %w", err)
+	}
+
+	err = svc.WriteConfig(ctx, path)
+	if err != nil {
+		return fmt.Errorf("failed to write config: %w", err)
+	}
+
+	return nil
+}
+
 // applyArgsToConfig applies command-line arguments to the configuration.
 // It takes arg of type *args and cfg of type *Config.
 // It does not return any values.

--- a/pkg/cmd/cfg_test.go
+++ b/pkg/cmd/cfg_test.go
@@ -300,3 +300,42 @@ func TestApplyArgsToConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestDownloadConfig_FailCreateSource(t *testing.T) {
+	ctx := context.Background()
+
+	cfg := &Config{
+		APISource: source.Config{
+			Etcd: source.EtcdConfig{
+				Servers: "localhost:2379",
+				Prefix:  "",
+			},
+		},
+	}
+
+	tempFilePath := os.TempDir() + "/test_download_config.yaml"
+	defer os.Remove(tempFilePath)
+
+	err := downloadConfig(ctx, cfg, tempFilePath)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create config source")
+}
+
+func TestDownloadConfig_FailWriteConfig(t *testing.T) {
+	ctx := context.Background()
+
+	path := createTempConfigFile(t, callsConfig)
+
+	cfg := &Config{
+		APISource: source.Config{
+			Path: path,
+		},
+	}
+
+	// Use an invalid path to trigger the write failure
+	invalidFilePath := "/invalid_path/test_download_config.yaml"
+
+	err := downloadConfig(ctx, cfg, invalidFilePath)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write config")
+}

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -165,6 +165,11 @@ func VerifyConfigCommand(arg *args) *cobra.Command {
 	}
 }
 
+// DownloadConfigCommand creates a new cobra.Command for downloading the config.
+// It takes arg of type *args which contains the necessary parameters for the command.
+// It returns a *cobra.Command that can be executed to download the config.
+// It returns an error if the logger initialization fails, the output path is not provided,
+// or if there is an error during the config initialization or download process.
 func DownloadConfigCommand(arg *args) *cobra.Command {
 	return &cobra.Command{
 		Use:   "download",

--- a/pkg/cmd/init_test.go
+++ b/pkg/cmd/init_test.go
@@ -39,8 +39,10 @@ func TestInitCommands(t *testing.T) {
 	assert.ElementsMatchf(t, []string{"server", "config"}, mapToNames(subCommands), "commands should match")
 
 	configCommands := findByName(subCommands, "config").Commands()
-	assert.Equal(t, 2, len(configCommands))
-	assert.Equal(t, "upload", configCommands[0].Use)
+	assert.Equal(t, 3, len(configCommands))
+	assert.Equal(t, "download", configCommands[0].Use)
+	assert.Equal(t, "upload", configCommands[1].Use)
+	assert.Equal(t, "verify", configCommands[2].Use)
 }
 
 func mapToNames(commands []*cobra.Command) []string {

--- a/pkg/cmd/init_test.go
+++ b/pkg/cmd/init_test.go
@@ -246,3 +246,72 @@ func TestVerifyConfigCommand_InvalidConfig(t *testing.T) {
 	err := cmd.ExecuteContext(cmd.Context())
 	assert.Error(t, err)
 }
+func TestDownloadConfigCommand_ValidOutput(t *testing.T) {
+	configPath := createTempConfigFile(t, validConfig)
+
+	arg := &args{
+		build:          "test-build",
+		version:        "test-version",
+		ConfigPath:     configPath,
+		LogLevel:       "debug",
+		TextFormat:     true,
+		downloadOutput: "valid-output-path",
+	}
+
+	cmd := DownloadConfigCommand(arg)
+
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "download", cmd.Use)
+	assert.Equal(t, "Download the config", cmd.Short)
+	assert.Equal(t, "Download the config for correctness", cmd.Long)
+
+	err := cmd.ExecuteContext(cmd.Context())
+
+	assert.Error(t, err)
+}
+
+func TestDownloadConfigCommand_InvalidOutput(t *testing.T) {
+	configPath := createTempConfigFile(t, validConfig)
+
+	arg := &args{
+		build:      "test-build",
+		version:    "test-version",
+		ConfigPath: configPath,
+		LogLevel:   "debug",
+		TextFormat: true,
+	}
+
+	cmd := DownloadConfigCommand(arg)
+
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "download", cmd.Use)
+	assert.Equal(t, "Download the config", cmd.Short)
+	assert.Equal(t, "Download the config for correctness", cmd.Long)
+
+	err := cmd.ExecuteContext(cmd.Context())
+	assert.Error(t, err)
+	assert.Equal(t, "output path is required", err.Error())
+}
+
+func TestDownloadConfigCommand_InvalidConfig(t *testing.T) {
+	configPath := createTempConfigFile(t, "invalid content")
+
+	arg := &args{
+		build:          "test-build",
+		version:        "test-version",
+		ConfigPath:     configPath,
+		LogLevel:       "debug",
+		TextFormat:     true,
+		downloadOutput: "valid-output-path",
+	}
+
+	cmd := DownloadConfigCommand(arg)
+
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "download", cmd.Use)
+	assert.Equal(t, "Download the config", cmd.Short)
+	assert.Equal(t, "Download the config for correctness", cmd.Long)
+
+	err := cmd.ExecuteContext(cmd.Context())
+	assert.Error(t, err)
+}

--- a/pkg/config/svc.go
+++ b/pkg/config/svc.go
@@ -197,6 +197,10 @@ func (c *Service) PutConfig(ctx context.Context) error {
 	return c.remote.PutConfig(ctx, c.curCfg)
 }
 
+// WriteConfig writes the configuration to a specified file path.
+// It takes a context.Context and a string representing the file path.
+// It returns an error if the remote source is nil, fails to load the config,
+// fails to create the file, or fails to encode the config.
 func (c *Service) WriteConfig(ctx context.Context, path string) error {
 	if c.remote == nil {
 		return fmt.Errorf("remote source is required")

--- a/pkg/config/svc_test.go
+++ b/pkg/config/svc_test.go
@@ -595,13 +595,11 @@ func TestService_onUpdate(t *testing.T) {
 }
 func TestService_WriteConfig(t *testing.T) {
 	tmpDir := os.TempDir()
-	defer os.RemoveAll(tmpDir)
 	ctx := context.Background()
-
 	tests := []struct {
+		localErr error
 		name     string
 		localCfg []handlerfactory.Config
-		localErr error
 		noRemote bool
 		wantErr  bool
 	}{

--- a/pkg/config/svc_test.go
+++ b/pkg/config/svc_test.go
@@ -593,6 +593,7 @@ func TestService_onUpdate(t *testing.T) {
 		})
 	}
 }
+
 func TestService_WriteConfig(t *testing.T) {
 	tmpDir := os.TempDir()
 	ctx := context.Background()
@@ -627,16 +628,16 @@ func TestService_WriteConfig(t *testing.T) {
 			mockBFFService := NewMockBFFService(t)
 			mockRemoteSource := NewMockRemoteSource(t)
 
-			if tt.noRemote {
-				mockRemoteSource = nil
-			}
-
 			svc := &Service{
 				bff:    mockBFFService,
 				remote: mockRemoteSource,
 			}
 
-			if tt.localErr != nil || tt.localCfg != nil {
+			if tt.noRemote {
+				svc.remote = nil
+			}
+
+			if !tt.noRemote && (tt.localErr != nil || tt.localCfg != nil) {
 				mockRemoteSource.EXPECT().LoadConfig(ctx).Return(tt.localCfg, tt.localErr)
 			}
 

--- a/pkg/config/svc_test.go
+++ b/pkg/config/svc_test.go
@@ -697,7 +697,7 @@ func TestService_WriteConfig_WriteToReadOnlyFile(t *testing.T) {
 	file, err := os.Create(filePath)
 	require.NoError(t, err)
 	require.NoError(t, file.Close())
-	require.NoError(t, os.Chmod(filePath, 0444))
+	require.NoError(t, os.Chmod(filePath, 0o444))
 
 	mockRemoteSource.EXPECT().LoadConfig(ctx).Return([]handlerfactory.Config{}, nil)
 


### PR DESCRIPTION
Add a basic implementation for saving configuration to a file, including error handling for various scenarios. A corresponding test case verifies the functionality.