### PR TITLE
Update wasabi dependency to v0.5.3 and improve test cleanup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.1
 require (
 	github.com/coder/websocket v1.8.12
 	github.com/google/uuid v1.6.0
-	github.com/ksysoev/wasabi v0.5.2
+	github.com/ksysoev/wasabi v0.5.3
 	github.com/prometheus/client_golang v1.20.5
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/ksysoev/ratestor v0.1.0 h1:zAlHYNXHyfwj78TnjUF6FHyYwkMcZxxxGul2DRhF4/
 github.com/ksysoev/ratestor v0.1.0/go.mod h1:ZJ3MX2d9JtBetKh9WMLvn0ESotKPJnl9rEU/qetyObk=
 github.com/ksysoev/wasabi v0.5.2 h1:oU0TIzQB2ebE03fTWFt7+CWgX2/amp4CNtJCvj0lJ+Q=
 github.com/ksysoev/wasabi v0.5.2/go.mod h1:nik5MCtksK5t1JD4A3Un2zfIAVHfPXkO6hegBmedcQY=
+github.com/ksysoev/wasabi v0.5.3 h1:CxFhbNvm/cofwjOKJdj4N48iv7j8AYoVlIpQlJH1vlM=
+github.com/ksysoev/wasabi v0.5.3/go.mod h1:nik5MCtksK5t1JD4A3Un2zfIAVHfPXkO6hegBmedcQY=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=

--- a/pkg/config/svc_test.go
+++ b/pkg/config/svc_test.go
@@ -695,6 +695,8 @@ func TestService_WriteConfig_WriteToReadOnlyFile(t *testing.T) {
 
 	// Create a read-only file
 	file, err := os.Create(filePath)
+	defer os.Remove(filePath)
+
 	require.NoError(t, err)
 	require.NoError(t, file.Close())
 	require.NoError(t, os.Chmod(filePath, 0o444))


### PR DESCRIPTION
Upgrade the wasabi dependency to the latest version and enhance test cleanup by ensuring temporary files are removed after tests.