### PR TITLE
Add health check endpoint and refactor request handling logic

### DIFF
--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+
+	request "github.com/ksysoev/deriv-api-bff/pkg/core/request"
+	wasabi "github.com/ksysoev/wasabi"
+)
+
+// Handle processes a request received on a connection and routes it based on the request type.
+// It takes conn of type wasabi.Connection and r of type wasabi.Request.
+// It returns an error if the request type is unsupported or if the request type is empty.
+// If the request type is core.TextMessage or core.BinaryMessage, it passes the request through to the handler.
+// For other request types, it processes the request using the handler.
+func (s *Service) Handle(conn wasabi.Connection, r wasabi.Request) error {
+	req, ok := r.(*request.Request)
+	if !ok {
+		return fmt.Errorf("unsupported request type: %T", req)
+	}
+
+	switch req.RoutingKey() {
+	case request.TextMessage, request.BinaryMessage:
+		return s.handler.PassThrough(conn, req)
+	case "":
+		return fmt.Errorf("empty request type: %v", req)
+	default:
+		return s.handler.ProcessRequest(conn, req)
+	}
+}
+
+// HealthCheck handles HTTP requests for checking the health status of the service.
+// It takes a ResponseWriter to write the HTTP response and a Request which represents the client's request.
+// It returns an HTTP status code 200 (OK) and a plain text message "OK".
+func (s *Service) HealthCheck(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("OK"))
+}

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	request "github.com/ksysoev/deriv-api-bff/pkg/core/request"
+	wasabi "github.com/ksysoev/wasabi"
+	"github.com/ksysoev/wasabi/mocks"
+	"github.com/stretchr/testify/assert"
+	mock "github.com/stretchr/testify/mock"
+)
+
+func TestService_Handle(t *testing.T) {
+	mockConn := mocks.NewMockConnection(t)
+	mockBFFService := NewMockBFFService(t)
+	service := NewSevice(&Config{}, mockBFFService)
+
+	mockBFFService.EXPECT().PassThrough(mockConn, mock.Anything).Return(nil)
+	mockBFFService.EXPECT().ProcessRequest(mockConn, mock.Anything).Return(nil)
+
+	tests := []struct {
+		request     wasabi.Request
+		name        string
+		expectError bool
+	}{
+		{
+			name:        "PassThrough TextMessage",
+			request:     request.NewRequest(context.Background(), request.TextMessage, []byte("test text message")),
+			expectError: false,
+		},
+		{
+			name:        "PassThrough BinaryMessage",
+			request:     request.NewRequest(context.Background(), request.BinaryMessage, []byte{0x01, 0x02, 0x03}),
+			expectError: false,
+		},
+		{
+			name:        "Empty Request Type",
+			request:     request.NewRequest(context.Background(), "", []byte("empty request type")),
+			expectError: true,
+		},
+		{
+			name:        "ProcessRequest CustomMessage",
+			request:     request.NewRequest(context.Background(), "customMessage", []byte("custom message")),
+			expectError: false,
+		},
+		{
+			name:        "Unsupported Request Type",
+			request:     mocks.NewMockRequest(t),
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := service.Handle(mockConn, tt.request)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestService_HealthCheck(t *testing.T) {
+	service := &Service{}
+
+	req, err := http.NewRequest("GET", "/livez", http.NoBody)
+	assert.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(service.HealthCheck)
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "OK", rr.Body.String())
+}

--- a/pkg/api/svc_test.go
+++ b/pkg/api/svc_test.go
@@ -9,7 +9,6 @@ import (
 	wasabi "github.com/ksysoev/wasabi"
 	"github.com/ksysoev/wasabi/mocks"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 func TestNewSevice(t *testing.T) {
@@ -88,57 +87,6 @@ func TestParse(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req := parse(nil, context.Background(), tt.msgType, tt.data)
 			assert.Equal(t, tt.expected, req)
-		})
-	}
-}
-func TestService_Handle(t *testing.T) {
-	mockConn := mocks.NewMockConnection(t)
-	mockBFFService := NewMockBFFService(t)
-	service := NewSevice(&Config{}, mockBFFService)
-
-	mockBFFService.EXPECT().PassThrough(mockConn, mock.Anything).Return(nil)
-	mockBFFService.EXPECT().ProcessRequest(mockConn, mock.Anything).Return(nil)
-
-	tests := []struct {
-		request     wasabi.Request
-		name        string
-		expectError bool
-	}{
-		{
-			name:        "PassThrough TextMessage",
-			request:     request.NewRequest(context.Background(), request.TextMessage, []byte("test text message")),
-			expectError: false,
-		},
-		{
-			name:        "PassThrough BinaryMessage",
-			request:     request.NewRequest(context.Background(), request.BinaryMessage, []byte{0x01, 0x02, 0x03}),
-			expectError: false,
-		},
-		{
-			name:        "Empty Request Type",
-			request:     request.NewRequest(context.Background(), "", []byte("empty request type")),
-			expectError: true,
-		},
-		{
-			name:        "ProcessRequest CustomMessage",
-			request:     request.NewRequest(context.Background(), "customMessage", []byte("custom message")),
-			expectError: false,
-		},
-		{
-			name:        "Unsupported Request Type",
-			request:     mocks.NewMockRequest(t),
-			expectError: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := service.Handle(mockConn, tt.request)
-			if tt.expectError {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
 		})
 	}
 }


### PR DESCRIPTION
Introduce a health check endpoint for service status verification and streamline the request handling logic for improved clarity and efficiency.