### PR TITLE
Fix linter configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,8 +59,6 @@ issues:
     - path: _test\.go$
       linters:
         - goconst
-exclude-files:
-  - _mock\.go$
 
 run:
   issues-exit-code: 1


### PR DESCRIPTION
Remove exclusion for mock files in the linter configuration to ensure all relevant files are checked.